### PR TITLE
store original front and back text to put back after review

### DIFF
--- a/src/flashcard-modal.ts
+++ b/src/flashcard-modal.ts
@@ -378,21 +378,21 @@ export class FlashcardModal extends Modal {
             if (this.currentCard.cardType == CardType.SingleLineBasic) {
                 fileText = fileText.replace(
                     replacementRegex,
-                    `${this.currentCard.front}${getSetting(
+                    `${this.currentCard.originalFrontText}${getSetting(
                         "singlelineCardSeparator",
                         this.plugin.data.settings
                     )}${
-                        this.currentCard.back
+                        this.currentCard.originalBackText
                     }${sep}<!--SR:${dueString},${interval},${ease}-->`
                 );
             } else {
                 fileText = fileText.replace(
                     replacementRegex,
-                    `${this.currentCard.front}\n${getSetting(
+                    `${this.currentCard.originalFrontText}\n${getSetting(
                         "multilineCardSeparator",
                         this.plugin.data.settings
                     )}\n${
-                        this.currentCard.back
+                        this.currentCard.originalBackText
                     }${sep}<!--SR:${dueString},${interval},${ease}-->`
                 );
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -516,15 +516,18 @@ export default class SRPlugin extends Plugin {
                     ? CardType.SingleLineBasic
                     : CardType.MultiLineBasic;
             for (let match of fileText.matchAll(regex)) {
-                match[0] = match[0].trim();
-                match[1] = await this.fixCardMediaLinks(
+                let cardText = match[0].trim();
+                let originalFrontText = match[1].trim();
+                let front = await this.fixCardMediaLinks(
                     match[1].trim(),
                     note.path
                 );
-                match[2] = await this.fixCardMediaLinks(
+                let originalBackText = match[2].trim();
+                let back = await this.fixCardMediaLinks(
                     match[2].trim(),
                     note.path
                 );
+                console.log("front", front);
                 let cardObj: Card;
                 // flashcard already scheduled
                 if (match[3]) {
@@ -541,10 +544,12 @@ export default class SRPlugin extends Plugin {
                             interval: parseInt(match[4]),
                             ease: parseInt(match[5]),
                             note,
-                            front: match[1],
-                            back: match[2],
-                            cardText: match[0],
+                            front,
+                            back,
+                            cardText,
                             context: "",
+                            originalFrontText,
+                            originalBackText,
                             cardType,
                         };
                         this.dueFlashcards[deck].push(cardObj);
@@ -554,12 +559,15 @@ export default class SRPlugin extends Plugin {
                     cardObj = {
                         isDue: false,
                         note,
-                        front: match[1],
-                        back: match[2],
-                        cardText: match[0],
+                        front,
+                        back,
+                        cardText,
                         context: "",
+                        originalFrontText,
+                        originalBackText,
                         cardType,
                     };
+                    console.log("cardObj", cardObj);
                     this.newFlashcards[deck].push(cardObj);
                     this.newFlashcardsCount++;
                 }
@@ -632,6 +640,8 @@ export default class SRPlugin extends Plugin {
                             back,
                             cardText: match[0],
                             context: "",
+                            originalFrontText: "",
+                            originalBackText: "",
                             cardType: CardType.Cloze,
                             subCardIdx: i,
                             relatedCards,
@@ -649,6 +659,8 @@ export default class SRPlugin extends Plugin {
                         back,
                         cardText: match[0],
                         context: "",
+                        originalFrontText: "",
+                        originalBackText: "",
                         cardType: CardType.Cloze,
                         subCardIdx: i,
                         relatedCards,
@@ -659,7 +671,7 @@ export default class SRPlugin extends Plugin {
                 }
 
                 relatedCards.push(cardObj);
-                if (getSetting("showContextInCards", this.plugin.data.settings))
+                if (getSetting("showContextInCards", this.data.settings))
                     addContextToCard(cardObj, match.index, headings);
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -527,7 +527,6 @@ export default class SRPlugin extends Plugin {
                     match[2].trim(),
                     note.path
                 );
-                console.log("front", front);
                 let cardObj: Card;
                 // flashcard already scheduled
                 if (match[3]) {
@@ -567,7 +566,6 @@ export default class SRPlugin extends Plugin {
                         originalBackText,
                         cardType,
                     };
-                    console.log("cardObj", cardObj);
                     this.newFlashcards[deck].push(cardObj);
                     this.newFlashcardsCount++;
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface Card {
     back: string;
     cardText: string;
     context: string;
+    originalFrontText: string;
+    originalBackText: string;
     // types
     cardType: CardType;
     // stuff for cards with sub-cards


### PR DESCRIPTION
This I think fixes the issue I brought up in https://github.com/st3v3nmw/obsidian-spaced-repetition/pull/73#issuecomment-845484017

I'm not sure where else the original back and front text could be used. I don't think Cloze cards will run into this same issue.
