### PR TITLE
Allow flashcard height and width to be customizable

### DIFF
--- a/src/flashcard-modal.ts
+++ b/src/flashcard-modal.ts
@@ -44,18 +44,10 @@ export class FlashcardModal extends Modal {
         this.titleEl.setText("Decks");
 
         if (Platform.isMobile) {
-            this.modalEl.style.height = "100%";
-            this.modalEl.style.width = "100%";
             this.contentEl.style.display = "block";
-        } else {
-            if (getSetting("largeScreenMode", this.plugin.data.settings)) {
-                this.modalEl.style.height = "100%";
-                this.modalEl.style.width = "100%";
-            } else {
-                this.modalEl.style.height = "80%";
-                this.modalEl.style.width = "40%";
-            }
         }
+        this.modalEl.style.height = getSetting("flashcardHeightPercentage", this.plugin.data.settings) + "%";
+        this.modalEl.style.width = getSetting("flashcardWidthPercentage", this.plugin.data.settings) + "%";
 
         this.contentEl.style.position = "relative";
         this.contentEl.style.height = "92%";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,7 +10,8 @@ export const DEFAULT_SETTINGS: SRSettings = {
     cardCommentOnSameLine: false,
     buryRelatedCards: false,
     showContextInCards: true,
-    largeScreenMode: false,
+    flashcardHeightPercentage: 80,
+    flashcardWidthPercentage: 40,
     showFileNameInFileLink: false,
     randomizeCardOrder: true,
     disableClozeCards: false,
@@ -170,17 +171,29 @@ export class SRSettingTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
-            .setName("Review cards in large screen mode?")
-            .setDesc("[Desktop] Should be useful if you have very large images")
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(
-                        getSetting("largeScreenMode", this.plugin.data.settings)
-                    )
-                    .onChange(async (value) => {
-                        this.plugin.data.settings.largeScreenMode = value;
-                        await this.plugin.savePluginData();
-                    })
+            .setName("Flashcard Height Percentage")
+            .setDesc("[Desktop] Should be set to 100% if you have very large images")
+            .addSlider((slider) =>
+                slider
+                  .setLimits(10, 100, 5)
+                  .setValue(getSetting("flashcardHeightPercentage", this.plugin.data.settings))
+                  .onChange(async (value) => {
+                     this.plugin.data.settings.flashcardHeightPercentage = value;
+                     await this.plugin.savePluginData();
+                  })
+            );
+
+        new Setting(containerEl)
+            .setName("Flashcard Width Percentage")
+            .setDesc("[Desktop] Should be set to 100% if you have very large images")
+            .addSlider((slider) =>
+                slider
+                  .setLimits(10, 100, 5)
+                  .setValue(getSetting("flashcardWidthPercentage", this.plugin.data.settings))
+                  .onChange(async (value) => {
+                     this.plugin.data.settings.flashcardWidthPercentage = value;
+                     await this.plugin.savePluginData();
+                  })
             );
 
         new Setting(containerEl)

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ export interface SRSettings {
     cardCommentOnSameLine: boolean;
     buryRelatedCards: boolean;
     showContextInCards: boolean;
-    largeScreenMode: boolean;
+    flashcardHeightPercentage: number;
+    flashcardWidthPercentage: number;
     showFileNameInFileLink: boolean;
     randomizeCardOrder: boolean;
     disableClozeCards: boolean;


### PR DESCRIPTION
I needed to be able to change this so that on iPad it's prettier and doesn't blow up images to fill up the whole screen. 

I did remove the largeDisplayMode setting as that's now doable by just making width and height 100%. That is a breaking change, but I'm not sure how much it was actually used. It's an easy fix on the user's side to just adjust both to 100%. Thoughts?
