### PR TITLE
Add option to ignore folders in note review

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -149,4 +149,9 @@ export default {
     Review: "Review",
     due: "due",
     Days: "Days",
+    "Folders to ignore": "Folders to ignore",
+    "Enter folder paths separated by newlines i.e. Templates Meta/Scripts": 
+        "Enter folder paths separated by newlines i.e. Templates Meta/Scripts",
+    "Note is saved under ignored folder (check settings).": 
+        "Note is saved under ignored folder (check settings).",
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -270,6 +270,7 @@ export default class SRPlugin extends Plugin {
                     graph.link(note.path, targetPath, links[targetPath]);
                 }
             }
+            if (this.data.settings.noteFoldersToIgnore.some(folder => note.path.startsWith(folder))) continue;
 
             let fileCachedData =
                 this.app.metadataCache.getFileCache(note) || {};
@@ -371,6 +372,15 @@ export default class SRPlugin extends Plugin {
         let frontmatter = fileCachedData.frontmatter || <Record<string, any>>{};
 
         let tags = getAllTags(fileCachedData) || [];
+        if (this.data.settings.noteFoldersToIgnore.some(folder => note.path.startsWith(folder))) {
+            new Notice(
+                t(
+                    "Note is saved under ignored folder (check settings)."
+                )
+            );
+            return;
+        }
+
         let shouldIgnore: boolean = true;
         outer: for (let tag of tags) {
             for (let tagToReview of this.data.settings.tagsToReview) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,6 +22,7 @@ export interface SRSettings {
     multilineReversedCardSeparator: string;
     // notes
     tagsToReview: string[];
+    noteFoldersToIgnore: string[];
     openRandomNote: boolean;
     autoNextNote: boolean;
     disableFileMenuReviewOptions: boolean;
@@ -54,6 +55,7 @@ export const DEFAULT_SETTINGS: SRSettings = {
     multilineReversedCardSeparator: "??",
     // notes
     tagsToReview: ["#review"],
+    noteFoldersToIgnore: [],
     openRandomNote: false,
     autoNextNote: false,
     disableFileMenuReviewOptions: false,
@@ -428,6 +430,25 @@ export class SRSettingTab extends PluginSettingTab {
                         applySettingsUpdate(async () => {
                             this.plugin.data.settings.tagsToReview =
                                 value.split(/\s+/);
+                            await this.plugin.savePluginData();
+                        });
+                    })
+            );
+        
+        new Setting(containerEl)
+            .setName(t("Folders to ignore"))
+            .setDesc(
+                t(
+                    "Enter folder paths separated by newlines i.e. Templates Meta/Scripts"
+                )
+            )
+            .addTextArea((text) =>
+                text
+                    .setValue(this.plugin.data.settings.noteFoldersToIgnore.join("\n"))
+                    .onChange((value) => {
+                        applySettingsUpdate(async () => {
+                            this.plugin.data.settings.noteFoldersToIgnore =
+                                value.split(/\n+/).map(v => v.trim()).filter(v => v);
                             await this.plugin.savePluginData();
                         });
                     })


### PR DESCRIPTION
Partially fixes #13 (added only for notes, not for flashcards --- I never used them so don't have any for testing)