### PR TITLE
Change "Open file"  to "Edit later"

### DIFF
--- a/src/flashcard-modal.ts
+++ b/src/flashcard-modal.ts
@@ -127,13 +127,20 @@ export class FlashcardModal extends Modal {
             this.fileLinkView.setAttribute("aria-label", t("OPEN_FILE"));
         }
         this.fileLinkView.addEventListener("click", async () => {
-            this.close();
-            await this.plugin.app.workspace.activeLeaf.openFile(this.currentCard.note);
-            const activeView: MarkdownView = this.app.workspace.getActiveViewOfType(MarkdownView);
-            activeView.editor.setCursor({
-                line: this.currentCard.lineNo,
-                ch: 0,
-            });
+            // @ts-ignore
+            const activeLeaf: WorkspaceLeaf = this.plugin.app.workspace.activeLeaf;
+            if (this.plugin.app.workspace.getActiveFile() === null)
+                activeLeaf.openFile(this.currentCard.note);
+            else {
+                const newLeaf = this.plugin.app.workspace.createLeafBySplit(activeLeaf, "vertical", false);
+                newLeaf.openFile(this.currentCard.note);
+            }
+            this.currentDeck.deleteFlashcardAtIndex(
+                this.currentCardIdx,
+                this.currentCard.isDue
+            );
+            this.burySiblingCards(false);
+            this.currentDeck.nextCard(this);
         });
 
         this.resetLinkView = this.contentEl.createDiv("sr-link");

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -6,7 +6,7 @@ export default {
     DUE_CARDS: "Due Cards",
     NEW_CARDS: "New Cards",
     TOTAL_CARDS: "Total Cards",
-    OPEN_FILE: "Open File",
+    OPEN_FILE: "Edit Later",
     RESET_CARD_PROGRESS: "Reset card's progress",
     HARD: "Hard",
     GOOD: "Good",


### PR DESCRIPTION
Make the "open file" open the file in the background for editing after the SR session ends. Thus, move the user to the next flashcard for review

This would  be an alternative solution  for the issue: https://github.com/st3v3nmw/obsidian-spaced-repetition/issues/269