### PR TITLE
Fix collapsed/expanded states when redrawing the sidebar

### DIFF
--- a/src/review-deck.ts
+++ b/src/review-deck.ts
@@ -12,7 +12,7 @@ export class ReviewDeck {
 
     constructor(name: string) {
         this.deckName = name;
-        this.activeFolders = new Set([t("Today")]);
+        this.activeFolders = new Set([this.deckName, t("TODAY")]);
     }
 
     public sortNotes(pageranks: Record<string, number>): void {


### PR DESCRIPTION
When the sidebar was redrawn, the deck and scheduled notes folders would return to the default expanded/collapsed setting. This makes sure they reflect the previous state when redrawing.

Also fix setting last reviewed deck when clicking on a note in the sidebar. Now when a note is clicked on the sidebar, the last reviewed deck is set to the selected note's deck.

This is the first fix that came to mind. It might not be the best way to do it but it has been working for me.