### PR TITLE
Using tags from User Preferences and not their full name that includes the sibling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -290,15 +290,14 @@ export default class SRPlugin extends Plugin {
             const tags = getAllTags(fileCachedData) || [];
 
             let shouldIgnore = true;
-            for (const tag of tags) {
-                if (
-                    this.data.settings.tagsToReview.some(
-                        (tagToReview) => tag === tagToReview || tag.startsWith(tagToReview + "/")
-                    )
-                ) {
-                    if (!Object.prototype.hasOwnProperty.call(this.reviewDecks, tag)) {
-                        this.reviewDecks[tag] = new ReviewDeck(tag);
+            const matchedNoteTags = [];
+
+            for (const tagToReview of this.data.settings.tagsToReview) {
+                if (tags.some((tag) => tag === tagToReview || tag.startsWith(tagToReview + "/"))) {
+                    if (!Object.prototype.hasOwnProperty.call(this.reviewDecks, tagToReview)) {
+                        this.reviewDecks[tagToReview] = new ReviewDeck(tagToReview);
                     }
+                    matchedNoteTags.push(tagToReview);
                     shouldIgnore = false;
                     break;
                 }
@@ -315,10 +314,8 @@ export default class SRPlugin extends Plugin {
                     Object.prototype.hasOwnProperty.call(frontmatter, "sr-ease")
                 )
             ) {
-                for (const tag of tags) {
-                    if (Object.prototype.hasOwnProperty.call(this.reviewDecks, tag)) {
-                        this.reviewDecks[tag].newNotes.push(note);
-                    }
+                for (const matchedNoteTag of matchedNoteTags) {
+                    this.reviewDecks[matchedNoteTag].newNotes.push(note);
                 }
                 continue;
             }
@@ -326,13 +323,11 @@ export default class SRPlugin extends Plugin {
             const dueUnix: number = window
                 .moment(frontmatter["sr-due"], ["YYYY-MM-DD", "DD-MM-YYYY", "ddd MMM DD YYYY"])
                 .valueOf();
-            for (const tag of tags) {
-                if (Object.prototype.hasOwnProperty.call(this.reviewDecks, tag)) {
-                    this.reviewDecks[tag].scheduledNotes.push({ note, dueUnix });
 
-                    if (dueUnix <= now.valueOf()) {
-                        this.reviewDecks[tag].dueNotesCount++;
-                    }
+            for (const matchedNoteTag of matchedNoteTags) {
+                this.reviewDecks[matchedNoteTag].scheduledNotes.push({ note, dueUnix });
+                if (dueUnix <= now.valueOf()) {
+                    this.reviewDecks[matchedNoteTag].dueNotesCount++;
                 }
             }
 


### PR DESCRIPTION
This fixes the issue of defineing a parent tag as a review tag and the plugin using the full tag which can clutter things up dramatically. e.g.

in the setting I have  #reference as a tag to review 

<img width="745" alt="Screenshot 2021-09-11 at 22 08 22" src="https://user-images.githubusercontent.com/1478194/132962469-15599f91-f252-4236-8acd-620fc504cdad.png">

but in the UI the plugin uses all the sibling tags like so 

<img width="244" alt="Screenshot 2021-09-11 at 22 07 41" src="https://user-images.githubusercontent.com/1478194/132962519-d7f19d35-11ff-4c43-b551-14f77716a6c2.png">


This fix uses the tags from the user preference in the UI to get this:

<img width="332" alt="Screenshot 2021-09-11 at 22 58 25" src="https://user-images.githubusercontent.com/1478194/132962563-7b859c8b-84a1-4faa-838a-979999e6e5e4.png">

Let me know your thoughts.

