### PR TITLE
Add fullscreen mode

### DIFF
--- a/src/flashcard-modal.ts
+++ b/src/flashcard-modal.ts
@@ -50,6 +50,10 @@ export class FlashcardModal extends Modal {
         }
         this.modalEl.style.height = this.plugin.data.settings.flashcardHeightPercentage + "%";
         this.modalEl.style.width = this.plugin.data.settings.flashcardWidthPercentage + "%";
+        if (this.plugin.data.settings.flashcardFullScreen) {
+            this.modalEl.style.minHeight = "100%";
+            this.modalEl.style.minWidth = "100%";
+        }
 
         this.contentEl.style.position = "relative";
         this.contentEl.style.height = "92%";
@@ -143,7 +147,7 @@ export class FlashcardModal extends Modal {
             activeView.editor.setCursor({
                 line: this.currentCard.lineNo,
                 ch: 0,
-            });            
+            });
             this.currentDeck.deleteFlashcardAtIndex(
                 this.currentCardIdx,
                 this.currentCard.isDue

--- a/src/flashcard-modal.ts
+++ b/src/flashcard-modal.ts
@@ -93,6 +93,8 @@ export class FlashcardModal extends Modal {
     }
 
     onClose(): void {
+        if (!Platform.isMobile && this.plugin.data.settings.flashcardFullScreen)
+            window.document.exitFullscreen();
         this.mode = FlashcardModalMode.Closed;
     }
 

--- a/src/flashcard-modal.ts
+++ b/src/flashcard-modal.ts
@@ -425,7 +425,7 @@ export class FlashcardModal extends Modal {
                     }, (img) => {
                         if (el.hasAttribute("width"))
                             img.setAttribute("width", el.getAttribute("width"));
-                        else
+                        else if (!this.plugin.data.settings.flashcardFullScreen)
                             img.setAttribute("width", "100%");
                         if (el.hasAttribute("alt"))
                             img.setAttribute("alt", el.getAttribute("alt"));

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -69,7 +69,7 @@ export default {
     RESET_DEFAULT: "Standardeinstellung wiederherstellen",
     CARD_MODAL_WIDTH_PERCENT: "Breite einer Lernkarte in Prozent",
     CARD_MODAL_FULL_SCREEN: "Vollbildschirmmodus",
-    CARD_MODAL_FULL_SCREEN_DESC: "Die Lernkarte wird immer auf der vollen Bildschirmbreite- und höhe angezeigt",
+    CARD_MODAL_FULL_SCREEN_DESC: "Zum Beenden die Taste `Esc` oder `F11` drücken oder das Fenster mit dem `X` rechts-oben schließen.",
     FILENAME_OR_OPEN_FILE: "Während der Wiederholung den Notiznamen statt 'Später bearbeiten' anzeigen?",
     RANDOMIZE_CARD_ORDER: "Während der Wiederhoung die Reihenfolge zufällig mischen?",
     DISABLE_CLOZE_CARDS: "Lückentextkarten (cloze deletions) deaktivieren?",

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -68,6 +68,8 @@ export default {
             "Auf kleinen Bildschirmen (z.B. Smartphones) oder bei sehr grossen Bildern sollte dieser Wert auf 100% gesetzt werden.",
     RESET_DEFAULT: "Standardeinstellung wiederherstellen",
     CARD_MODAL_WIDTH_PERCENT: "Breite einer Lernkarte in Prozent",
+    CARD_MODAL_FULL_SCREEN: "Vollbildschirmmodus",
+    CARD_MODAL_FULL_SCREEN_DESC: "Die Lernkarte wird immer auf der vollen Bildschirmbreite- und höhe angezeigt",
     FILENAME_OR_OPEN_FILE: "Während der Wiederholung den Notiznamen statt 'Später bearbeiten' anzeigen?",
     RANDOMIZE_CARD_ORDER: "Während der Wiederhoung die Reihenfolge zufällig mischen?",
     DISABLE_CLOZE_CARDS: "Lückentextkarten (cloze deletions) deaktivieren?",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -66,7 +66,7 @@ export default {
     RESET_DEFAULT: "Reset to default",
     CARD_MODAL_WIDTH_PERCENT: "Flashcard Width Percentage",
     CARD_MODAL_FULL_SCREEN: "Fullscreen Mode",
-    CARD_MODAL_FULL_SCREEN_DESC: "The card is always displayed with the full width and height of the screen.",
+    CARD_MODAL_FULL_SCREEN_DESC: "Use `Esc` or `F11` or the top-right `x` to exit",
     FILENAME_OR_OPEN_FILE: "Show file name instead of 'Edit Later' in flashcard review?",
     RANDOMIZE_CARD_ORDER: "Randomize card order during review?",
     DISABLE_CLOZE_CARDS: "Disable cloze cards?",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -65,6 +65,8 @@ export default {
         "Should be set to 100% on mobile or if you have very large images",
     RESET_DEFAULT: "Reset to default",
     CARD_MODAL_WIDTH_PERCENT: "Flashcard Width Percentage",
+    CARD_MODAL_FULL_SCREEN: "Fullscreen Mode",
+    CARD_MODAL_FULL_SCREEN_DESC: "The card is always displayed with the full width and height of the screen.",
     FILENAME_OR_OPEN_FILE: "Show file name instead of 'Edit Later' in flashcard review?",
     RANDOMIZE_CARD_ORDER: "Randomize card order during review?",
     DISABLE_CLOZE_CARDS: "Disable cloze cards?",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, TAbstractFile, TFile, HeadingCache, getAllTags } from "obsidian";
+import { Notice, Plugin, TAbstractFile, TFile, HeadingCache, getAllTags, Platform } from "obsidian";
 import * as graph from "pagerank.js";
 
 import { SRSettingTab, SRSettings, DEFAULT_SETTINGS } from "src/settings";
@@ -88,7 +88,7 @@ export default class SRPlugin extends Plugin {
         this.addRibbonIcon("SpacedRepIcon", t("REVIEW_CARDS"), async () => {
             await this.sync();
 
-            if (this.data.settings.flashcardFullScreen)
+            if (!Platform.isMobile && this.data.settings.flashcardFullScreen)
                 window.document.documentElement.requestFullscreen();
             new FlashcardModal(this.app, this).open();
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,6 +87,9 @@ export default class SRPlugin extends Plugin {
 
         this.addRibbonIcon("SpacedRepIcon", t("REVIEW_CARDS"), async () => {
             await this.sync();
+
+            if (this.data.settings.flashcardFullScreen)
+                window.document.documentElement.requestFullscreen();
             new FlashcardModal(this.app, this).open();
         });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export interface SRSettings {
     showContextInCards: boolean;
     flashcardHeightPercentage: number;
     flashcardWidthPercentage: number;
+    flashcardFullScreen: boolean;
     showFileNameInFileLink: boolean;
     randomizeCardOrder: boolean;
     convertHighlightsToClozes: boolean;
@@ -227,6 +228,18 @@ export class SRSettingTab extends PluginSettingTab {
                         this.display();
                     });
             });
+
+        new Setting(containerEl)
+            .setName(t("CARD_MODAL_FULL_SCREEN"))
+            .setDesc(t("CARD_MODAL_FULL_SCREEN_DESC"))
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.data.settings.flashcardFullScreen)
+                    .onChange(async (value) => {
+                        this.plugin.data.settings.flashcardFullScreen = value;
+                        await this.plugin.savePluginData();
+                    })
+            );
 
         new Setting(containerEl).setName(t("FILENAME_OR_OPEN_FILE")).addToggle((toggle) =>
             toggle

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,7 @@ export const DEFAULT_SETTINGS: SRSettings = {
     showContextInCards: true,
     flashcardHeightPercentage: Platform.isMobile ? 100 : 80,
     flashcardWidthPercentage: Platform.isMobile ? 100 : 40,
+    flashcardFullScreen: false,
     showFileNameInFileLink: false,
     randomizeCardOrder: true,
     convertHighlightsToClozes: true,

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@
 
 .sr-deck-counts {
     color: #ffffff;
-    margin-left: 4px; 
+    margin-left: 4px;
 }
 
 #sr-show-answer {
@@ -76,6 +76,10 @@
 #sr-flashcard-view {
     overflow-y: auto;
     height: 80%;
+}
+
+#sr-flashcard-view img {
+    object-fit: none;
 }
 
 .sr-ignorestats-btn{

--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,10 @@
         display: none;
     }
 
+    #sr-flashcard-view img {
+        min-width: 100%;
+    }
+
     .sr-response,
     #sr-show-answer {
         width: 95% !important;

--- a/styles.css
+++ b/styles.css
@@ -79,7 +79,10 @@
 }
 
 #sr-flashcard-view img {
-    object-fit: none;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 50%;
 }
 
 .sr-ignorestats-btn{


### PR DESCRIPTION
This change adds a new toggle option called "Fullscreen Mode" to the settings, which basically sets the min-height and min-width css property to 100%. The result is that the modal is always using 100% of the screen size, regardless of the actual card content. 

- On my iPad and iPhone it removes the ~20% size top margin -> 20% more card content visible!
- On my desktop it hides any note content in the background, which might disturb from the actual content. -> increased focus!