### PR TITLE
Changing interpolate to an optional arg of t

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     preset: "ts-jest",
     testEnvironment: "jsdom",
     moduleNameMapper: {
-        "src/(.*)": "<rootDir>/src/$1"
-    }
+        "src/(.*)": "<rootDir>/src/$1",
+    },
+    roots: ["<rootDir>/src/", "<rootDir>/tests/"]
 };

--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -53,10 +53,23 @@ const localeMap: { [k: string]: Partial<typeof en> } = {
 
 const locale = localeMap[moment.locale()];
 
-export function t(str: keyof typeof en): string {
+// https://stackoverflow.com/a/41015840/
+function interpolate(str: string, params: Record<string, unknown>): string {
+    const names: string[] = Object.keys(params);
+    const vals: unknown[] = Object.values(params);
+    return new Function(...names, `return \`${str}\`;`)(...vals);
+}
+
+export function t(str: keyof typeof en, params?: Record<string, unknown>): string {
     if (!locale) {
         console.error("Error: SRS locale not found", moment.locale());
     }
 
-    return (locale && locale[str]) || en[str];
+    const result = (locale && locale[str]) || en[str];
+
+    if(params) {
+        return interpolate(result, params);
+    }
+
+    return result;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,13 +44,6 @@ export interface LinkStat {
     linkCount: number;
 }
 
-// https://stackoverflow.com/a/41015840/
-String.prototype.interpolate = function (params: Record<string, unknown>) {
-    const names: string[] = Object.keys(params);
-    const vals: unknown[] = Object.values(params);
-    return new Function(...names, `return \`${this}\`;`)(...vals);
-};
-
 export default class SRPlugin extends Plugin {
     private statusBar: HTMLElement;
     private reviewQueueView: ReviewQueueListView;
@@ -380,14 +373,14 @@ export default class SRPlugin extends Plugin {
         if (this.data.settings.showDebugMessages) {
             console.log(
                 "SR: " +
-                    t("SYNC_TIME_TAKEN").interpolate({
+                    t("SYNC_TIME_TAKEN", {
                         t: Date.now() - now.valueOf(),
                     })
             );
         }
 
         this.statusBar.setText(
-            t("STATUS_BAR").interpolate({
+            t("STATUS_BAR", {
                 dueNotesCount: this.dueNotesCount,
                 dueFlashcardsCount: this.deckTree.dueFlashcardsCount,
             })
@@ -548,7 +541,7 @@ export default class SRPlugin extends Plugin {
 
     async reviewNextNote(deckKey: string): Promise<void> {
         if (!Object.prototype.hasOwnProperty.call(this.reviewDecks, deckKey)) {
-            new Notice(t("NO_DECK_EXISTS").interpolate({ deckName: deckKey }));
+            new Notice(t("NO_DECK_EXISTS", { deckName: deckKey }));
             return;
         }
 

--- a/src/scheduling.ts
+++ b/src/scheduling.ts
@@ -104,11 +104,11 @@ export function textInterval(interval: number, isMobile: boolean): string {
         else return `${y}y`;
     } else {
         if (interval < 30) {
-            return t("DAYS_STR_IVL").interpolate({ interval });
+            return t("DAYS_STR_IVL", { interval });
         } else if (interval < 365) {
-            return t("MONTHS_STR_IVL").interpolate({ interval: m });
+            return t("MONTHS_STR_IVL", { interval: m });
         } else {
-            return t("YEARS_STR_IVL").interpolate({ interval: y });
+            return t("YEARS_STR_IVL", { interval: y });
         }
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -93,7 +93,7 @@ export class SRSettingTab extends PluginSettingTab {
 
         containerEl.createDiv().innerHTML = "<h2>" + t("SETTINGS_HEADER") + "</h2>";
 
-        containerEl.createDiv().innerHTML = t("CHECK_WIKI").interpolate({
+        containerEl.createDiv().innerHTML = t("CHECK_WIKI", {
             wiki_url: "https://github.com/st3v3nmw/obsidian-spaced-repetition/wiki",
         });
 
@@ -449,7 +449,7 @@ export class SRSettingTab extends PluginSettingTab {
             });
 
         containerEl.createDiv().innerHTML = "<h3>" + t("ALGORITHM") + "</h3>";
-        containerEl.createDiv().innerHTML = t("CHECK_ALGORITHM_WIKI").interpolate({
+        containerEl.createDiv().innerHTML = t("CHECK_ALGORITHM_WIKI", {
             algo_url:
                 "https://github.com/st3v3nmw/obsidian-spaced-repetition/wiki/Spaced-Repetition-Algorithm",
         });

--- a/src/stats-modal.ts
+++ b/src/stats-modal.ts
@@ -91,7 +91,7 @@ export class StatsModal extends Modal {
             "\tstacked: true\n" +
             "````\n" +
             "\n<div style='text-align:center'>" +
-            t("REVIEWS_PER_DAY").interpolate({ avg: (scheduledCount / maxN).toFixed(1) }) +
+            t("REVIEWS_PER_DAY", { avg: (scheduledCount / maxN).toFixed(1) }) +
             "</div>";
 
         maxN = Math.max(...getKeysPreserveType(cardStats.intervals));
@@ -140,7 +140,7 @@ export class StatsModal extends Modal {
             "\tstacked: true\n" +
             "````\n" +
             "\n<div style='text-align:center'>" +
-            t("INTERVALS_SUMMARY").interpolate({
+            t("INTERVALS_SUMMARY", {
                 avg: average_interval,
                 longest: longest_interval,
             }) +
@@ -179,7 +179,7 @@ export class StatsModal extends Modal {
             "\tstacked: true\n" +
             "````\n" +
             "\n<div style='text-align:center'>" +
-            t("EASES_SUMMARY").interpolate({ avgEase: average_ease }) +
+            t("EASES_SUMMARY", { avgEase: average_ease }) +
             "</div>";
 
         // Add card types
@@ -206,7 +206,7 @@ export class StatsModal extends Modal {
             "\tlabelColors: true\n" +
             "```\n" +
             "\n<div style='text-align:center'>" +
-            t("CARD_TYPES_SUMMARY").interpolate({ totalCardsCount }) +
+            t("CARD_TYPES_SUMMARY", { totalCardsCount }) +
             "</div>";
 
         MarkdownRenderer.renderMarkdown(text, contentEl, "", this.plugin);

--- a/tests/__mocks__/obsidian.js
+++ b/tests/__mocks__/obsidian.js
@@ -1,0 +1,5 @@
+module.exports = {
+    moment: {
+        locale: jest.fn(()=>"en")
+    }
+};

--- a/tests/lang/helpers.test.ts
+++ b/tests/lang/helpers.test.ts
@@ -1,0 +1,43 @@
+test("Test translation without interpolation in English", () => {
+    jest.isolateModules(() => {
+        const { moment } = require("obsidian");
+        const mockLocale = moment.locale as jest.MockedFunction<() => string>;
+        mockLocale.mockImplementation(() => 'en');
+        const {t} = require("src/lang/helpers");
+        expect(t("HARD")).toEqual("Hard");
+    });
+});
+
+test("Test translation without interpolation in German", () => {
+    jest.isolateModules(() => {
+        const { moment } = require("obsidian");
+        const mockLocale = moment.locale as jest.MockedFunction<() => string>;
+        mockLocale.mockImplementation(() => 'de');
+        const {t} = require("src/lang/helpers");
+        expect(t("HARD")).toEqual("Schwer");
+    });
+});
+
+test("Test translation with interpolation in English", () => {
+    jest.isolateModules(() => {
+        const { moment } = require("obsidian");
+        const mockLocale = moment.locale as jest.MockedFunction<() => string>;
+        mockLocale.mockImplementation(() => 'en');
+        const {t} = require("src/lang/helpers");
+        expect(
+            t("STATUS_BAR", {dueNotesCount: 1, dueFlashcardsCount: 2})
+        ).toEqual("Review: 1 notes(s), 2 card(s) due");
+    });
+});
+
+test("Test translation with interpolation in German", () => {
+    jest.isolateModules(() => {
+        const { moment } = require("obsidian");
+        const mockLocale = moment.locale as jest.MockedFunction<() => string>;
+        mockLocale.mockImplementation(() => 'de');
+        const {t} = require("src/lang/helpers");
+        expect(
+            t("STATUS_BAR", {dueNotesCount: 1, dueFlashcardsCount: 2})
+        ).toEqual("Wiederholung: 1 Notiz(en), 2 Karte(n) anstehend");
+    });
+});


### PR DESCRIPTION
While we can't change the existing Obsidian API that sometimes extends string with new methods, it's not necessary to extend string when we only need interpolation when calling t for translated strings...

This PR makes it a small bit easier to test scheduling.ts by avoiding the need to provide a global interpolate function for every string.

Provided some unit tests for translation and interpolation, just to make sure it continued to work as expected.