### PR TITLE
Correct notes(s) to note(s) in en.ts lang file

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -27,7 +27,7 @@ export default {
     CRAM_CARDS_IN_NOTE: "Cram flashcards in this note.",
     REVIEW_ALL_CARDS: "Review flashcards from all notes",
     VIEW_STATS: "View statistics",
-    STATUS_BAR: "Review: ${dueNotesCount} notes(s), ${dueFlashcardsCount} card(s) due",
+    STATUS_BAR: "Review: ${dueNotesCount} note(s), ${dueFlashcardsCount} card(s) due",
     SYNC_TIME_TAKEN: "Sync took ${t}ms",
     NOTE_IN_IGNORED_FOLDER: "Note is saved under ignored folder (check settings).",
     PLEASE_TAG_NOTE: "Please tag the note appropriately for reviewing (in settings).",


### PR DESCRIPTION
I just downloaded the plugin and noticed this mistake in the English lang file.

It's a small change, so it should be an easy merge.

Thank you for making this plugin :)