### PR TITLE
[Bug fix] for HTML Comment parsing

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,7 +35,7 @@ export function parse(
             cardText = "";
             continue;
         } else if (lines[i].startsWith("<!--") && !lines[i].startsWith("<!--SR:")) {
-            while (i + 1 < lines.length && !lines[i + 1].includes("-->")) i++;
+            while (i + 1 < lines.length && !lines[i].includes("-->")) i++;
             i++;
             continue;
         }


### PR DESCRIPTION
as seen in #349 
code checking for the comment end checks on the next line rather than the same line 
This causes some causing parsing issues.