### PR TITLE
fix: handle code fences better

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -74,12 +74,13 @@ export function parse(
         } else if (lines[i] === multilineReversedCardSeparator) {
             cardType = CardType.MultiLineReversed;
             lineNo = i;
-        } else if (lines[i].startsWith("```")) {
-            while (i + 1 < lines.length && !lines[i + 1].startsWith("```")) {
+        } else if (lines[i].startsWith("```") | lines[i].startsWith("~~~")) {
+            let codeBlockClose = lines[i].match(/`+|~+/);
+            while (i + 1 < lines.length && !lines[i + 1].startsWith(codeBlockClose)) {
                 i++;
                 cardText += "\n" + lines[i];
             }
-            cardText += "\n" + "```";
+            cardText += "\n" + codeBlockClose;
             i++;
         }
     }


### PR DESCRIPTION
Markdown has two code fences syntaxes: multiple backticks and multiple tildes. It also supports nested code fences. For example

`````markdown
An admonition:

````ad-note

```git
+ print("hello")
- print("world")
```

~~~python
print("hello world")
~~~
````
`````

This pull request makes the plugin support the more general Markdown code fences syntax.