### PR TITLE
Add "ogg" as supported audio file format

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const MULTI_SCHEDULING_EXTRACTOR = /!([\d-]+),(\d+),(\d+)/gm;
 export const LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;
 
 export const IMAGE_FORMATS = ["jpg", "jpeg", "gif", "png", "svg"];
-export const AUDIO_FORMATS = ["mp3", "webm", "m4a", "wav"];
+export const AUDIO_FORMATS = ["mp3", "webm", "m4a", "wav", "ogg"];
 export const VIDEO_FORMATS = ["mp4", "mkv", "avi", "mov"];
 
 export const CROSS_HAIRS_ICON =


### PR DESCRIPTION
Was pulling my hair out trying to figure out why an audio file wouldn't embed -- turns out ogg wasn't supported! I modified the constant in the exported .js file and now it works just fine.