### PR TITLE
[feat] add modal history feature

### DIFF
--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -106,6 +106,18 @@ export class FlashcardModal extends Modal {
     }
 
     decksList(): void {
+        const aimDeck = this.plugin.deckTree.subdecks.filter(
+            (deck) => deck.deckName === this.plugin.data.historyDeck
+        );
+        if (this.plugin.data.historyDeck && aimDeck.length > 0) {
+            const deck = aimDeck[0];
+            this.currentDeck = deck;
+            this.checkDeck = deck.parent;
+            this.setupCardsView();
+            deck.nextCard(this);
+            return;
+        }
+
         this.mode = FlashcardModalMode.DecksList;
         this.titleEl.setText(t("DECKS"));
         this.titleEl.innerHTML += (
@@ -143,6 +155,15 @@ export class FlashcardModal extends Modal {
 
     setupCardsView(): void {
         this.contentEl.innerHTML = "";
+        const historyLinkView = this.contentEl.createEl("button");
+
+        historyLinkView.setText("〈");
+        historyLinkView.addEventListener("click", (e: PointerEvent) => {
+            if (e.pointerType.length > 0) {
+                this.plugin.data.historyDeck = "";
+                this.decksList();
+            }
+        });
 
         this.fileLinkView = this.contentEl.createDiv("sr-link");
         this.fileLinkView.setText(t("EDIT_LATER"));
@@ -662,6 +683,7 @@ export class Deck {
 
         const deckViewInner: HTMLElement = deckViewSelf.createDiv("tree-item-inner");
         deckViewInner.addEventListener("click", () => {
+            modal.plugin.data.historyDeck = this.deckName;
             modal.currentDeck = this;
             modal.checkDeck = this.parent;
             modal.setupCardsView();
@@ -726,6 +748,7 @@ export class Deck {
             }
 
             if (this.parent == modal.checkDeck) {
+                modal.plugin.data.historyDeck = "";
                 modal.decksList();
             } else {
                 this.parent.nextCard(modal);

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,12 +33,14 @@ interface PluginData {
     // should work as long as user doesn't modify card's text
     // which covers most of the cases
     buryList: string[];
+    historyDeck: string | null;
 }
 
 const DEFAULT_DATA: PluginData = {
     settings: DEFAULT_SETTINGS,
     buryDate: "",
     buryList: [],
+    historyDeck: null,
 };
 
 export interface SchedNote {


### PR DESCRIPTION
I find it will be much more convenient if the deck list can remember which entry the user have clicked before exiting the window. So I implemented this feature and have tested for several monthes. It works well so I do PR to the upstream.