### PR TITLE
style: set the flashcard's font size as user editor

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,7 @@
 }
 
 #sr-flashcard-view {
+    font-size: var(--font-text-size);
     overflow-y: auto;
     height: 80%;
 }


### PR DESCRIPTION
Currently, the font size of the flashcard is 16px, although the user might change the font size for the editor in the setting panel. 

It will be reasonable to set the flashcard's font size as the user set