### PR TITLE
Bug 495 card should be added to all tagged decks not just the first one

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -590,8 +590,8 @@ export default class SRPlugin extends Plugin {
         let deckPaths: string[][] = [];
         if (this.data.settings.convertFoldersToDecks) {
             deckPaths[0] = note.path.split("/");
-            deckPaths.pop(); // remove filename
-            if (deckPaths.length === 0) {
+            deckPaths[0].pop(); // remove filename
+            if (deckPaths[0].length === 0) {
                 deckPaths[0] = ["/"];
             }
         } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -343,14 +343,7 @@ export default class SRPlugin extends Plugin {
                 continue;
             }
 
-            // file has no scheduling information
-            if (
-                !(
-                    Object.prototype.hasOwnProperty.call(frontmatter, "sr-due") &&
-                    Object.prototype.hasOwnProperty.call(frontmatter, "sr-interval") &&
-                    Object.prototype.hasOwnProperty.call(frontmatter, "sr-ease")
-                )
-            ) {
+            if (!fileHasSchedulingInformation(frontmatter)) {
                 for (const matchedNoteTag of matchedNoteTags) {
                     this.reviewDecks[matchedNoteTag].newNotes.push(note);
                 }
@@ -453,13 +446,7 @@ export default class SRPlugin extends Plugin {
         let ease: number, interval: number, delayBeforeReview: number;
         const now: number = Date.now();
         // new note
-        if (
-            !(
-                Object.prototype.hasOwnProperty.call(frontmatter, "sr-due") &&
-                Object.prototype.hasOwnProperty.call(frontmatter, "sr-interval") &&
-                Object.prototype.hasOwnProperty.call(frontmatter, "sr-ease")
-            )
-        ) {
+        if (!fileHasSchedulingInformation(frontmatter)) {
             let linkTotal = 0,
                 linkPGTotal = 0,
                 totalLinkCount = 0;
@@ -918,4 +905,14 @@ function getCardContext(cardLine: number, headings: HeadingCache[]): string {
         context += headingObj.heading + " > ";
     }
     return context.slice(0, -3);
+}
+
+function fileHasSchedulingInformation(
+    frontmatter: FrontMatterCache | Record<string, unknown>
+): boolean {
+    return (
+        Object.prototype.hasOwnProperty.call(frontmatter, "sr-due") &&
+        Object.prototype.hasOwnProperty.call(frontmatter, "sr-interval") &&
+        Object.prototype.hasOwnProperty.call(frontmatter, "sr-ease")
+    );
 }

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,11 +1,12 @@
 import { parse } from "src/parser";
 import { CardType } from "src/scheduling";
 
-const defaultArgs: [string, string, string, string, boolean, boolean] = [
+const defaultArgs: [string, string, string, string, boolean, boolean, boolean] = [
     "::",
     ":::",
     "?",
     "??",
+    true,
     true,
     true,
 ];
@@ -110,7 +111,9 @@ test("Test parsing of cloze cards", () => {
     expect(parse("lorem ipsum ==p\ndolor won==", ...defaultArgs)).toEqual([]);
     expect(parse("lorem ipsum ==dolor won=", ...defaultArgs)).toEqual([]);
     // ==highlights== turned off
-    expect(parse("cloze ==deletion== test", "::", ":::", "?", "??", false, true)).toEqual([]);
+    expect(parse("cloze ==deletion== test", "::", ":::", "?", "??", false, true, false)).toEqual(
+        []
+    );
 
     // **bolded**
     expect(parse("cloze **deletion** test", ...defaultArgs)).toEqual([
@@ -139,7 +142,9 @@ test("Test parsing of cloze cards", () => {
     expect(parse("lorem ipsum **p\ndolor won**", ...defaultArgs)).toEqual([]);
     expect(parse("lorem ipsum **dolor won*", ...defaultArgs)).toEqual([]);
     // **bolded** turned off
-    expect(parse("cloze **deletion** test", "::", ":::", "?", "??", true, false)).toEqual([]);
+    expect(parse("cloze **deletion** test", "::", ":::", "?", "??", true, false, false)).toEqual(
+        []
+    );
 
     // both
     expect(parse("cloze **deletion** test ==another deletion==!", ...defaultArgs)).toEqual([


### PR DESCRIPTION
I have a change which fixes #495, allowing a card to be added simultaneously to multiple decks if the note is tagged with multiple valid deck tags.

This does lead to some questionable behavior, where if a user tags the same note with `#parentTag` and `#parentTag/childTag`, then the cards in that note will be single-counted in the `#parentTag/childTag` deck (which is fine), but double-counted in the `#parentTag` deck (which seems weird, but hey it's what they've literally asked for by doing that).

# Example of what I mean

Here's the contents of the note:
![image](https://user-images.githubusercontent.com/9409476/194683065-a2c29841-c55c-4715-a741-8c7fc6bac92c.png)

and here's the resulting UI from this plugin when you use the 'cram flashcards in this note' command:
![image](https://user-images.githubusercontent.com/9409476/194683083-a09d9d07-edb5-4785-b8ff-a07e3fabb765.png)

I'm not sure if this is how we want the plugin to behave, or if we would perhaps like to make it configurable by having a setting that determines what happens in this situation. I'm open to suggestions, as I haven't been using the `obsidian-spaced-repetition` plugin personally for very long so I don't have a good feel for what makes sense here.