### PR TITLE
Prevent regex from matching to last --- in file

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const SCHEDULING_INFO_REGEX =
-    /^---\n((?:.*\n)*)sr-due: (.+)\nsr-interval: (\d+)\nsr-ease: (\d+)\n((?:.*\n)*)---/;
+    /^---\n((?:.*\n)*)sr-due: (.+)\nsr-interval: (\d+)\nsr-ease: (\d+)\n((?:.*\n)?)---/;
 export const YAML_FRONT_MATTER_REGEX = /^---\n((?:.*\n)*?)---/;
 
 export const MULTI_SCHEDULING_EXTRACTOR = /!([\d-]+),(\d+),(\d+)/gm;


### PR DESCRIPTION
Addresses #527 by changing `SCHEDULING_INFO_REGEX` to only match to next `---`.