### PR TITLE
Implementation of same-day reviews for 1 minute & 10 minutes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build
 
 # coverage
 coverage
+
+# Temp for hot reloads
+main.js

--- a/data.json
+++ b/data.json
@@ -1,0 +1,44 @@
+{
+  "settings": {
+    "flashcardEasyText": "Easy",
+    "flashcardGoodText": "Good",
+    "flashcardHardText": "Hard",
+    "flashcardTags": [
+      "#flashcards"
+    ],
+    "convertFoldersToDecks": false,
+    "cardCommentOnSameLine": false,
+    "burySiblingCards": false,
+    "showContextInCards": true,
+    "flashcardHeightPercentage": 80,
+    "flashcardWidthPercentage": 40,
+    "showFileNameInFileLink": false,
+    "randomizeCardOrder": true,
+    "convertHighlightsToClozes": true,
+    "convertBoldTextToClozes": false,
+    "convertCurlyBracketsToClozes": false,
+    "singleLineCardSeparator": "::",
+    "singleLineReversedCardSeparator": ":::",
+    "multilineCardSeparator": "?",
+    "multilineReversedCardSeparator": "??",
+    "enableNoteReviewPaneOnStartup": true,
+    "tagsToReview": [
+      "#review"
+    ],
+    "noteFoldersToIgnore": [],
+    "openRandomNote": false,
+    "autoNextNote": false,
+    "disableFileMenuReviewOptions": false,
+    "maxNDaysNotesReviewQueue": 365,
+    "initiallyExpandAllSubdecksInTree": false,
+    "baseEase": 250,
+    "lapsesIntervalChange": 0.5,
+    "easyBonus": 1.3,
+    "maximumInterval": 36525,
+    "maxLinkFactor": 1,
+    "showDebugMessages": true
+  },
+  "buryDate": "2022-12-28",
+  "buryList": [],
+  "historyDeck": null
+}

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -25,6 +25,7 @@ esbuild
         sourcemap: "inline",
         sourcesContent: !prod,
         treeShaking: true,
-        outfile: "build/main.js",
+        // outfile: "build/main.js",
+        outfile: "./main.js",
     })
     .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     },
     "dependencies": {
         "chart.js": "^4.0.1",
+        "i": "^0.3.7",
         "pagerank.js": "^1.0.2"
     },
     "packageManager": "npm@8.18.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "author": "Stephen Mwangi",
     "license": "MIT",
     "devDependencies": {
+        "@types/heap": "^0.2.31",
         "@types/jest": "^29.2.4",
         "@types/node": "^18.11.13",
         "@types/vhtml": "^2.2.4",
@@ -34,6 +35,7 @@
     },
     "dependencies": {
         "chart.js": "^4.0.1",
+        "heap": "^0.2.7",
         "i": "^0.3.7",
         "pagerank.js": "^1.0.2"
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,8 @@ export const SCHEDULING_INFO_REGEX =
     /^---\n((?:.*\n)*)sr-due: (.+)\nsr-interval: (\d+)\nsr-ease: (\d+)\n((?:.*\n)?)---/;
 export const YAML_FRONT_MATTER_REGEX = /^---\n((?:.*\n)*?)---/;
 
-export const MULTI_SCHEDULING_EXTRACTOR = /!([\d-]+),(\d+),(\d+)/gm;
-export const LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;
+export const LEGACY_MULTI_SCHEDULING_EXTRACTOR = /!([\d-]+),(\d+),(\d+)/gm;
+export const LEGACY_LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;
 
 export const IMAGE_FORMATS = ["jpg", "jpeg", "gif", "png", "svg"];
 export const AUDIO_FORMATS = ["mp3", "webm", "m4a", "wav", "ogg"];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,8 @@ export const SCHEDULING_INFO_REGEX =
     /^---\n((?:.*\n)*)sr-due: (.+)\nsr-interval: (\d+)\nsr-ease: (\d+)\n((?:.*\n)?)---/;
 export const YAML_FRONT_MATTER_REGEX = /^---\n((?:.*\n)*?)---/;
 
-export const LEGACY_MULTI_SCHEDULING_EXTRACTOR = /!([\d-]+),(\d+),(\d+)/gm;
-export const LEGACY_LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;
+export const MULTI_SCHEDULING_EXTRACTOR = /!([-\d :]+),(\d+),(\d+)/gm;
+export const LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;
 
 export const IMAGE_FORMATS = ["jpg", "jpeg", "gif", "png", "svg"];
 export const AUDIO_FORMATS = ["mp3", "webm", "m4a", "wav", "ogg"];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const YAML_FRONT_MATTER_REGEX = /^---\n((?:.*\n)*?)---/;
 
 export const MULTI_SCHEDULING_EXTRACTOR = /!([-\d :]+),(\d+),(\d+)/gm;
 export const LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;
+export const MINUTES_PER_DAY = 24 * 60;
 
 export const IMAGE_FORMATS = ["jpg", "jpeg", "gif", "png", "svg"];
 export const AUDIO_FORMATS = ["mp3", "webm", "m4a", "wav", "ogg"];

--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -15,8 +15,8 @@ import type SRPlugin from "src/main";
 import { Card, CardType, schedule, textInterval, ReviewResponse } from "src/scheduling";
 import {
     COLLAPSE_ICON,
-    MULTI_SCHEDULING_EXTRACTOR,
-    LEGACY_SCHEDULING_EXTRACTOR,
+    LEGACY_MULTI_SCHEDULING_EXTRACTOR,
+    LEGACY_LEGACY_SCHEDULING_EXTRACTOR,
     IMAGE_FORMATS,
     AUDIO_FORMATS,
     VIDEO_FORMATS,
@@ -318,6 +318,9 @@ export class FlashcardModal extends Modal {
                     this.plugin.dueDatesFlashcards
                 );
             } else {
+
+                // First time this card was reviewed, so need to 
+                // add data to it.
                 let initial_ease: number = this.plugin.data.settings.baseEase;
                 if (
                     Object.prototype.hasOwnProperty.call(
@@ -375,10 +378,10 @@ export class FlashcardModal extends Modal {
                 this.currentCard.cardText + sep + `<!--SR:!${dueString},${interval},${ease}-->`;
         } else {
             let scheduling: RegExpMatchArray[] = [
-                ...this.currentCard.cardText.matchAll(MULTI_SCHEDULING_EXTRACTOR),
+                ...this.currentCard.cardText.matchAll(LEGACY_MULTI_SCHEDULING_EXTRACTOR),
             ];
             if (scheduling.length === 0) {
-                scheduling = [...this.currentCard.cardText.matchAll(LEGACY_SCHEDULING_EXTRACTOR)];
+                scheduling = [...this.currentCard.cardText.matchAll(LEGACY_LEGACY_SCHEDULING_EXTRACTOR)];
             }
 
             const currCardSched: string[] = ["0", dueString, interval.toString(), ease.toString()];

--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -229,6 +229,8 @@ export class FlashcardModal extends Modal {
 
         this.responseDiv = this.contentEl.createDiv("sr-response");
 
+        // TODO: Add 'impossible' button. Requires adding for all languages.
+
         this.hardBtn = document.createElement("button");
         this.hardBtn.setAttribute("id", "sr-hard-btn");
         this.hardBtn.setText(this.plugin.data.settings.flashcardHardText);
@@ -346,7 +348,7 @@ export class FlashcardModal extends Modal {
 
             interval = schedObj.interval;
             ease = schedObj.ease;
-            due = window.moment(Date.now() + interval * 24 * 3600 * 1000);
+            due = window.moment(Date.now() + interval * 60 * 1000);
         } else {
             this.currentCard.interval = 1.0;
             this.currentCard.ease = this.plugin.data.settings.baseEase;
@@ -362,7 +364,7 @@ export class FlashcardModal extends Modal {
         }
 
         // TODO: Change to only include time if re-reviewing on same day
-        const dueString: string = due.format(t("DATE_SCHED_FMT"));
+        const dueString: string = due.format("YYYY-MM-DD");
 
         let fileText: string = await this.app.vault.read(this.currentCard.note);
         const replacementRegex = new RegExp(escapeRegexString(this.currentCard.cardText), "gm");

--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -310,7 +310,7 @@ export class FlashcardModal extends Modal {
 
         // Exit early if doing a reset
         if (response === ReviewResponse.Reset) {
-            const newCard: Card = {...this.currentCard};
+            const newCard: Card = { ...this.currentCard };
             newCard.interval = 1.0;
             newCard.ease = this.plugin.data.settings.baseEase;
             this.currentDeck.notifyCardChanged(this.currentCardIdx, newCard);
@@ -319,7 +319,7 @@ export class FlashcardModal extends Modal {
             this.currentDeck.nextCard(this);
             return;
         }
-        
+
         let schedObj: Record<string, number>;
         // scheduled card
         if (this.currentCard.isDue) {
@@ -332,8 +332,7 @@ export class FlashcardModal extends Modal {
                 this.plugin.dueDatesFlashcards
             );
         } else {
-
-            // First time this card was reviewed, so need to 
+            // First time this card was reviewed, so need to
             // add data to it.
             let initial_ease: number = this.plugin.data.settings.baseEase;
             if (
@@ -410,13 +409,13 @@ export class FlashcardModal extends Modal {
         if (this.plugin.data.settings.burySiblingCards) {
             this.burySiblingCards(true);
         }
-        
+
         await this.app.vault.modify(this.currentCard.note, fileText);
 
         // Update the card within the deck if we need to re-review it.
         // Otherwise, delete the card from the deck.
         if (interval < MINUTES_PER_DAY) {
-            const newCard = {...this.currentCard};  // Need to copy so that old card's data persists
+            const newCard = { ...this.currentCard }; // Need to copy so that old card's data persists
             newCard.isDue = true;
             newCard.isReDue = true;
             newCard.interval = interval;
@@ -440,7 +439,7 @@ export class FlashcardModal extends Modal {
 
         let idx;
         for (const sibling of this.currentCard.siblings) {
-            while ((idx = this.currentDeck.flashcards.indexOf(sibling)) != -1)  {
+            while ((idx = this.currentDeck.flashcards.indexOf(sibling)) != -1) {
                 this.currentDeck.deleteFlashcardAtIndex(
                     idx,
                     this.currentDeck.flashcards[idx].isDue
@@ -635,8 +634,7 @@ export class Deck {
         }
 
         // Card was just deleted, don't increment total count;
-        if (!cardObj.isReDue)
-            this.totalFlashcards++;
+        if (!cardObj.isReDue) this.totalFlashcards++;
 
         if (deckPath.length === 0) {
             Heap.push(this.flashcards, cardObj, Deck.comparator);
@@ -670,7 +668,7 @@ export class Deck {
     deleteFlashcardAtIndex(index: number, cardIsDue: boolean, base = true): void {
         if (base) {
             this.flashcards.splice(index, 1);
-            Heap.heapify(this.flashcards, Deck.comparator);    
+            Heap.heapify(this.flashcards, Deck.comparator);
         }
 
         if (cardIsDue) {
@@ -679,8 +677,7 @@ export class Deck {
             this.newFlashcardsCount--;
         }
 
-        if (this.parent !== null)
-            this.parent.deleteFlashcardAtIndex(index, cardIsDue, false);
+        if (this.parent !== null) this.parent.deleteFlashcardAtIndex(index, cardIsDue, false);
     }
 
     notifyCardChanged(oldCardIdx: number, newCard: Card): void {
@@ -693,7 +690,6 @@ export class Deck {
             root = deck;
             deck = deck.parent;
         }
-
 
         root.insertFlashcard(deckName.reverse().slice(1, deckName.length), newCard);
     }
@@ -804,7 +800,7 @@ export class Deck {
             }
             return;
         }
-        
+
         // Actually get next card.
         Heap.heapify(this.flashcards, Deck.comparator);
 
@@ -824,7 +820,7 @@ export class Deck {
 
         if (this.flashcards.length > 0) {
             // TODO: Explain why we needed to "look for first unscheduled sibling"
-            modal.currentCardIdx = 0;  // Heap incorporates randomness based on settings
+            modal.currentCardIdx = 0; // Heap incorporates randomness based on settings
 
             modal.currentCard = this.flashcards[modal.currentCardIdx];
             modal.renderMarkdownWrapper(modal.currentCard.front, modal.flashcardView);
@@ -901,40 +897,36 @@ export class Deck {
     }
 
     /**
-     * 
+     *
      * @param a One card to compare with another
      * @param b The other card to compare
      * @returns +1 => b should be reviewed first, -1 => a should be reviewed first, 0 => no preference
-    */
-   static comparator(a: Card, b: Card): number {
-       
-       // New cards are reviewed after due cards.
-       if (!a.isDue && !b.isDue)
-       return 0;
-       if (a.isDue && !b.isDue)
-       return -1;
-       if (!a.isDue && b.isDue)
-        return 1;
-        
+     */
+    static comparator(a: Card, b: Card): number {
+        // New cards are reviewed after due cards.
+        if (!a.isDue && !b.isDue) return 0;
+        if (a.isDue && !b.isDue) return -1;
+        if (!a.isDue && b.isDue) return 1;
+
         const now = window.moment(Date.now()).valueOf();
-        
+
         // Both redue
         if (a.isReDue && b.isReDue) {
             const aReviewDelay = a.previousReview + a.interval * 60 * 1000 - now;
             const bReviewDelay = b.previousReview + b.interval * 60 * 1000 - now;
-            
-            return (aReviewDelay < bReviewDelay) ? -1 : 1;
+
+            return aReviewDelay < bReviewDelay ? -1 : 1;
         }
-        
+
         // One redue, other is due
         if (a.isReDue) {
             const aDiff = now - a.previousReview + a.interval * 60 * 1000;
-            return (aDiff > 0) ? 1 : -1;
+            return aDiff > 0 ? 1 : -1;
         } else if (b.isReDue) {
             const bDiff = now - b.previousReview + b.interval * 60 * 1000;
-            return (bDiff > 0) ? -1 : 1;
+            return bDiff > 0 ? -1 : 1;
         }
-        
+
         // Both due, don't care which is reviewed first
         // Currently assume randomness
         // TODO: Access whether to randomize or not

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -43,6 +43,7 @@ export default {
     DAYS_STR_IVL_MOBILE: "${interval}d",
     MONTHS_STR_IVL_MOBILE: "${interval}m",
     YEARS_STR_IVL_MOBILE: "${interval}y",
+    DATE_SCHED_FMT: "YYYY-MM-DD hh:mm:ss",
 
     // settings.ts
     SETTINGS_HEADER: "Spaced Repetition Plugin - Settings",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -37,13 +37,15 @@ export default {
     ALL_CAUGHT_UP: "You're all caught up now :D.",
 
     // scheduling.ts
+    // TODO: Translate MINUTES_X to other langs
+    MINUTES_STR_IVL: "${interval} minutes(s)",
     DAYS_STR_IVL: "${interval} day(s)",
     MONTHS_STR_IVL: "${interval} month(s)",
     YEARS_STR_IVL: "${interval} year(s)",
+    MINUTES_STR_IVL_MOBILE: "${interval}m",
     DAYS_STR_IVL_MOBILE: "${interval}d",
-    MONTHS_STR_IVL_MOBILE: "${interval}m",
+    MONTHS_STR_IVL_MOBILE: "${interval}mo",
     YEARS_STR_IVL_MOBILE: "${interval}y",
-    DATE_SCHED_FMT: "YYYY-MM-DD hh:mm:ss",
 
     // settings.ts
     SETTINGS_HEADER: "Spaced Repetition Plugin - Settings",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -46,6 +46,7 @@ export default {
     DAYS_STR_IVL_MOBILE: "${interval}d",
     MONTHS_STR_IVL_MOBILE: "${interval}mo",
     YEARS_STR_IVL_MOBILE: "${interval}y",
+    DATE_SCHED_FMT: "YYYY-MM-DD HH:mm:ss",
 
     // settings.ts
     SETTINGS_HEADER: "Spaced Repetition Plugin - Settings",

--- a/src/main.ts
+++ b/src/main.ts
@@ -760,7 +760,7 @@ export default class SRPlugin extends Plugin {
             let scheduling: RegExpMatchArray[] = [...cardText.matchAll(MULTI_SCHEDULING_EXTRACTOR)];
             if (scheduling.length === 0)
                 scheduling = [...cardText.matchAll(LEGACY_SCHEDULING_EXTRACTOR)];
-            
+
             // we have some extra scheduling dates to delete
             if (scheduling.length > siblingMatches.length) {
                 const idxSched: number = cardText.lastIndexOf("<!--SR:") + 7;

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,8 @@ import { Card, CardType, ReviewResponse, schedule } from "src/scheduling";
 import {
     YAML_FRONT_MATTER_REGEX,
     SCHEDULING_INFO_REGEX,
-    LEGACY_LEGACY_SCHEDULING_EXTRACTOR,
-    LEGACY_MULTI_SCHEDULING_EXTRACTOR,
+    LEGACY_SCHEDULING_EXTRACTOR,
+    MULTI_SCHEDULING_EXTRACTOR,
 } from "src/constants";
 import { escapeRegexString, cyrb53 } from "src/utils";
 import { ReviewDeck, ReviewDeckSelectionModal } from "src/review-deck";
@@ -645,6 +645,7 @@ export default class SRPlugin extends Plugin {
             settings.convertBoldTextToClozes,
             settings.convertCurlyBracketsToClozes
         );
+
         for (const parsedCard of parsedCards) {
             deckPath = noteDeckPath;
             const cardType: CardType = parsedCard[0],
@@ -755,10 +756,10 @@ export default class SRPlugin extends Plugin {
             }
 
             // TODO: Update scheduling information to minutes
-            let scheduling: RegExpMatchArray[] = [...cardText.matchAll(LEGACY_MULTI_SCHEDULING_EXTRACTOR)];
+            let scheduling: RegExpMatchArray[] = [...cardText.matchAll(MULTI_SCHEDULING_EXTRACTOR)];
             if (scheduling.length === 0)
-                scheduling = [...cardText.matchAll(LEGACY_LEGACY_SCHEDULING_EXTRACTOR)];
-
+                scheduling = [...cardText.matchAll(LEGACY_SCHEDULING_EXTRACTOR)];
+            
             // we have some extra scheduling dates to delete
             if (scheduling.length > siblingMatches.length) {
                 const idxSched: number = cardText.lastIndexOf("<!--SR:") + 7;
@@ -782,6 +783,7 @@ export default class SRPlugin extends Plugin {
 
                 const cardObj: Card = {
                     isDue: i < scheduling.length,
+                    isReDue: false,
                     note,
                     lineNo,
                     front,
@@ -800,7 +802,7 @@ export default class SRPlugin extends Plugin {
                     this.deckTree.insertFlashcard([...deckPath], cardObj);
                 } else if (i < scheduling.length) {
                     const dueUnix: number = window
-                        .moment(scheduling[i][1], ["YYYY-MM-DD", "DD-MM-YYYY"])
+                        .moment(scheduling[i][1], ["YYYY-MM-DD", "DD-MM-YYYY", t("DATE_SCHED_FMT")])
                         .valueOf();
                     const nDays: number = Math.ceil((dueUnix - now) / (24 * 3600 * 1000));
                     if (!Object.prototype.hasOwnProperty.call(this.dueDatesFlashcards, nDays)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,8 @@ import { Card, CardType, ReviewResponse, schedule } from "src/scheduling";
 import {
     YAML_FRONT_MATTER_REGEX,
     SCHEDULING_INFO_REGEX,
-    LEGACY_SCHEDULING_EXTRACTOR,
-    MULTI_SCHEDULING_EXTRACTOR,
+    LEGACY_LEGACY_SCHEDULING_EXTRACTOR,
+    LEGACY_MULTI_SCHEDULING_EXTRACTOR,
 } from "src/constants";
 import { escapeRegexString, cyrb53 } from "src/utils";
 import { ReviewDeck, ReviewDeckSelectionModal } from "src/review-deck";
@@ -754,9 +754,9 @@ export default class SRPlugin extends Plugin {
                 }
             }
 
-            let scheduling: RegExpMatchArray[] = [...cardText.matchAll(MULTI_SCHEDULING_EXTRACTOR)];
+            let scheduling: RegExpMatchArray[] = [...cardText.matchAll(LEGACY_MULTI_SCHEDULING_EXTRACTOR)];
             if (scheduling.length === 0)
-                scheduling = [...cardText.matchAll(LEGACY_SCHEDULING_EXTRACTOR)];
+                scheduling = [...cardText.matchAll(LEGACY_LEGACY_SCHEDULING_EXTRACTOR)];
 
             // we have some extra scheduling dates to delete
             if (scheduling.length > siblingMatches.length) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -417,6 +417,7 @@ export default class SRPlugin extends Plugin {
     }
 
     async saveReviewResponse(note: TFile, response: ReviewResponse): Promise<void> {
+        console.log("HAHAHA");
         const fileCachedData = this.app.metadataCache.getFileCache(note) || {};
         const frontmatter: FrontMatterCache | Record<string, unknown> =
             fileCachedData.frontmatter || {};
@@ -802,7 +803,7 @@ export default class SRPlugin extends Plugin {
                     this.deckTree.insertFlashcard([...deckPath], cardObj);
                 } else if (i < scheduling.length) {
                     const dueUnix: number = window
-                        .moment(scheduling[i][1], ["YYYY-MM-DD", "DD-MM-YYYY"])
+                        .moment(scheduling[i][1], ["YYYY-MM-DD", "DD-MM-YYYY", t("DATE_SCHED_FMT")])
                         .valueOf();
                     const nDays: number = Math.ceil((dueUnix - now) / (24 * 3600 * 1000));
                     if (!Object.prototype.hasOwnProperty.call(this.dueDatesFlashcards, nDays)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -802,7 +802,7 @@ export default class SRPlugin extends Plugin {
                     this.deckTree.insertFlashcard([...deckPath], cardObj);
                 } else if (i < scheduling.length) {
                     const dueUnix: number = window
-                        .moment(scheduling[i][1], ["YYYY-MM-DD", "DD-MM-YYYY", t("DATE_SCHED_FMT")])
+                        .moment(scheduling[i][1], ["YYYY-MM-DD", "DD-MM-YYYY"])
                         .valueOf();
                     const nDays: number = Math.ceil((dueUnix - now) / (24 * 3600 * 1000));
                     if (!Object.prototype.hasOwnProperty.call(this.dueDatesFlashcards, nDays)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -754,6 +754,7 @@ export default class SRPlugin extends Plugin {
                 }
             }
 
+            // TODO: Update scheduling information to minutes
             let scheduling: RegExpMatchArray[] = [...cardText.matchAll(LEGACY_MULTI_SCHEDULING_EXTRACTOR)];
             if (scheduling.length === 0)
                 scheduling = [...cardText.matchAll(LEGACY_LEGACY_SCHEDULING_EXTRACTOR)];

--- a/src/scheduling.ts
+++ b/src/scheduling.ts
@@ -15,6 +15,7 @@ export enum ReviewResponse {
 export interface Card {
     // scheduling
     isDue: boolean;
+    isReDue: boolean;
     interval?: number;
     ease?: number;
     delayBeforeReview?: number;

--- a/src/scheduling.ts
+++ b/src/scheduling.ts
@@ -2,6 +2,7 @@ import { TFile } from "obsidian";
 
 import { SRSettings } from "src/settings";
 import { t } from "src/lang/helpers";
+import { MINUTES_PER_DAY } from "./constants";
 
 export enum ReviewResponse {
     Easy,
@@ -42,6 +43,16 @@ export enum CardType {
     Cloze,
 }
 
+/**
+ * 
+ * @param response Whether or not the card was labelled 'easy', 'good', or 'hard'
+ * @param interval The interval in minutes between the previous review and when the card becomes available for review.
+ * @param ease The internal ease of the card
+ * @param delayBeforeReview Difference in ms between a card's scheduled review time & when its actually reviewed.
+ * @param settingsObj The global settings object
+ * @param dueDates The array of due dates (for statistics)
+ * @returns Object containing the new scheduling interval & ease of the card.
+ */
 export function schedule(
     response: ReviewResponse,
     interval: number,
@@ -50,20 +61,32 @@ export function schedule(
     settingsObj: SRSettings,
     dueDates?: Record<number, number>
 ): Record<string, number> {
-    delayBeforeReview = Math.max(0, Math.floor(delayBeforeReview / (24 * 3600 * 1000)));
+    const minutesBeforeReview: number = Math.max(0, Math.floor(delayBeforeReview / (60 * 1000)));
 
-    if (response === ReviewResponse.Easy) {
-        ease += 20;
-        interval = ((interval + delayBeforeReview) * ease) / 100;
-        interval *= settingsObj.easyBonus;
-    } else if (response === ReviewResponse.Good) {
-        interval = ((interval + delayBeforeReview / 2) * ease) / 100;
-    } else if (response === ReviewResponse.Hard) {
-        ease = Math.max(130, ease - 20);
-        interval = Math.max(
-            1,
-            (interval + delayBeforeReview / 4) * settingsObj.lapsesIntervalChange
-        );
+    if (interval < MINUTES_PER_DAY) {
+        if (response === ReviewResponse.Easy) {
+            ease += 20;
+            interval = MINUTES_PER_DAY;
+        } else if (response === ReviewResponse.Good) {
+            interval = 10;
+        } else {
+            interval = 1;
+            ease = Math.max(settingsObj.baseEase, ease - 20);
+        }
+    } else {
+        if (response === ReviewResponse.Easy) {
+            ease += 20;
+            interval = ((interval + minutesBeforeReview) * ease) / 100;
+            interval *= settingsObj.easyBonus;
+        } else if (response === ReviewResponse.Good) {
+            interval = ((interval + minutesBeforeReview / 2) * ease) / 100;
+        } else if (response === ReviewResponse.Hard) {
+            ease = Math.max(settingsObj.baseEase, ease - 20);
+            interval = Math.max(
+                1,
+                (interval + minutesBeforeReview / 4) * settingsObj.lapsesIntervalChange
+            );
+        }
     }
 
     // replaces random fuzz with load balancing over the fuzz interval
@@ -73,17 +96,22 @@ export function schedule(
             dueDates[interval] = 0;
         } else {
             // disable fuzzing for small intervals
-            if (interval > 4) {
+            if (interval > 4 * MINUTES_PER_DAY) {
                 let fuzz = 0;
-                if (interval < 7) fuzz = 1;
-                else if (interval < 30) fuzz = Math.max(2, Math.floor(interval * 0.15));
-                else fuzz = Math.max(4, Math.floor(interval * 0.05));
+
+                if (interval < 7 * MINUTES_PER_DAY) {
+                    fuzz = MINUTES_PER_DAY;
+                } else if (interval < 30 * MINUTES_PER_DAY) {
+                    fuzz = Math.max(2, Math.floor(interval * 0.15));
+                } else {
+                    fuzz = Math.max(4, Math.floor(interval * 0.05));
+                }
 
                 const originalInterval = interval;
                 outer: for (let i = 1; i <= fuzz; i++) {
                     for (const ivl of [originalInterval - i, originalInterval + i]) {
                         if (!Object.prototype.hasOwnProperty.call(dueDates, ivl)) {
-                            dueDates[ivl] = 0;
+                            dueDates[Math.round(ivl / MINUTES_PER_DAY)] = 0;
                             interval = ivl;
                             break outer;
                         }
@@ -93,25 +121,33 @@ export function schedule(
             }
         }
 
-        dueDates[interval]++;
+        dueDates[Math.round(interval / MINUTES_PER_DAY)]++;
     }
 
-    interval = Math.min(interval, settingsObj.maximumInterval);
+    interval = Math.min(interval, settingsObj.maximumInterval * MINUTES_PER_DAY);
+    if (interval < 10) {
+        interval = 1;
+    } else if (interval < MINUTES_PER_DAY) {
+        interval = 10;
+    }
 
     return { interval: Math.round(interval * 10) / 10, ease };
 }
 
 export function textInterval(interval: number, isMobile: boolean): string {
-    const m: number = Math.round(interval / 3.04375) / 10,
-        y: number = Math.round(interval / 36.525) / 10;
+    const days: number = Math.round(interval / (24 * 60)),
+        months: number = Math.round(days / 3.04375) / 10,
+        years: number = Math.round(days / 36.525) / 10;
 
     if (isMobile) {
-        if (m < 1.0) return t("DAYS_STR_IVL_MOBILE", { interval });
-        else if (y < 1.0) return t("MONTHS_STR_IVL_MOBILE", { interval: m });
-        else return t("YEARS_STR_IVL_MOBILE", { interval: y });
+        if (days < 1.0) return t("MINUTES_STR_IVL_MOBILE", { interval });
+        if (months < 1.0) return t("DAYS_STR_IVL_MOBILE", { interval: days });
+        if (years < 1.0) return t("MONTHS_STR_IVL_MOBILE", { interval: months });
+        return t("YEARS_STR_IVL_MOBILE", { interval: years });
     } else {
-        if (m < 1.0) return t("DAYS_STR_IVL", { interval });
-        else if (y < 1.0) return t("MONTHS_STR_IVL", { interval: m });
-        else return t("YEARS_STR_IVL", { interval: y });
+        if (days < 1.0) return t("MINUTES_STR_IVL", { interval });
+        if (months < 1.0) return t("DAYS_STR_IVL", { interval: days });
+        if (years < 1.0) return t("MONTHS_STR_IVL", { interval: months });
+        return t("YEARS_STR_IVL", { interval: years });
     }
 }

--- a/src/scheduling.ts
+++ b/src/scheduling.ts
@@ -74,6 +74,7 @@ export function schedule(
             ease = Math.max(settingsObj.baseEase, ease - 20);
         }
     } else {
+        // TODO: Change old algorithm to deal with minutes? How?
         if (response === ReviewResponse.Easy) {
             ease += 20;
             interval = ((interval + minutesBeforeReview) * ease) / 100;
@@ -124,6 +125,7 @@ export function schedule(
         dueDates[Math.round(interval / MINUTES_PER_DAY)]++;
     }
 
+    // Round down to 1m and 10m for consistency
     interval = Math.min(interval, settingsObj.maximumInterval * MINUTES_PER_DAY);
     if (interval < 10) {
         interval = 1;

--- a/src/scheduling.ts
+++ b/src/scheduling.ts
@@ -20,6 +20,7 @@ export interface Card {
     interval?: number;
     ease?: number;
     delayBeforeReview?: number;
+    previousReview?: number;
     // note
     note: TFile;
     lineNo: number;

--- a/src/scheduling.ts
+++ b/src/scheduling.ts
@@ -45,7 +45,7 @@ export enum CardType {
 }
 
 /**
- * 
+ *
  * @param response Whether or not the card was labelled 'easy', 'good', or 'hard'
  * @param interval The interval in minutes between the previous review and when the card becomes available for review.
  * @param ease The internal ease of the card


### PR DESCRIPTION
This PR implements the ability to review a card in 1 minute or 10 minute intervals, (partially) addressing issues #502 and #503. These minute intervals are hardcoded and so an interval of 2.5 minutes, for example, is not possible. Several major changes were required to implement such a feature. These include:
1. Changing the 'interval attribute of a flashcard' from days to minutes
2. Changing the format of the review date to include hours, minutes, & seconds
3. Tracking flashcards in a heap rather than an array, using a custom comparison function (Deck.comparator in flashcard-modal.tsx)
   1. Required addition of [heap.js](https://www.npmjs.com/package/heap) NPM package.
4.  Changing content of the "Card" interface.

There are several topics I would like cleared up before I open this PR for review & approval. One thing I'm unclear on is the use of sibling cards. I would appreciate if other maintainers could explain the point of tracking sibling cards. Specifically, what's the point of lines 811-819 in flashcard-modal.tsx:
```ts
                // look for first unscheduled sibling
                const pickedCard: Card = this.newFlashcards[pickedCardIdx];
                let idx = pickedCardIdx;
                while (idx >= 0 && pickedCard.siblings.includes(this.newFlashcards[idx])) {
                    if (!this.newFlashcards[idx].isDue) {
                        modal.currentCardIdx = idx;
                    }
                    idx--;
                }
```
I also understand that it may be too early in the roadmap to implement, as the scheduling algorithm is being changed and that might want to be merged first. My hope in making this pull request is to get this feature implemented before or soon after the winter semester starts. I greatly enjoyed using this plugin in the fall semester, but found myself falling back on Anki due to the lack of same-day reviews. Having all flashcards in one place would make my own life and the lives of other users much easier.

Still TODO before approval:
- Revert build location to build/main.js. 
- Include other languages for updated constant strings
- Implement option to not randomize card review order. Currently, program forces randomization of flashcards
- Update scheduling.test.ts to use minutes
- Testing with multiple nested decks & flashcards.
- Testing with sibling cards (what are these)
- Ensuring ability to review notes has not changed.

Let me know if anyone has questions or concerns about this PR! I'd be happy to address them.