### PR TITLE
Added option to include custom additions to the Frontmatter text

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -97,6 +97,8 @@ export default {
     REVIEW_PANE_ON_STARTUP: "Enable note review pane on startup",
     TAGS_TO_REVIEW: "Tags to review",
     TAGS_TO_REVIEW_DESC: "Enter tags separated by spaces or newlines i.e. #review #tag2 #tag3.",
+    FRONTMATTER_NAME: "Frontmatter addition",
+    FRONTMATTER_NAME_DESC: "Enter an additional name to include in frontmatter, useful if multiple people want to review the same notes. If you use `-simon` the tags in frontmatter will become `sr-due-simon`.",
     OPEN_RANDOM_NOTE: "Open a random note for review",
     OPEN_RANDOM_NOTE_DESC: "When you turn this off, notes are ordered by importance (PageRank).",
     AUTO_NEXT_NOTE: "Open next note automatically after a review",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ export interface SRSettings {
     // notes
     enableNoteReviewPaneOnStartup: boolean;
     tagsToReview: string[];
+    reviewFrontmatter: string[];
     noteFoldersToIgnore: string[];
     openRandomNote: boolean;
     autoNextNote: boolean;
@@ -67,6 +68,7 @@ export const DEFAULT_SETTINGS: SRSettings = {
     // notes
     enableNoteReviewPaneOnStartup: true,
     tagsToReview: ["#review"],
+    reviewFrontmatter: [""],
     noteFoldersToIgnore: [],
     openRandomNote: false,
     autoNextNote: false,
@@ -469,6 +471,20 @@ export class SRSettingTab extends PluginSettingTab {
                     .onChange((value) => {
                         applySettingsUpdate(async () => {
                             this.plugin.data.settings.tagsToReview = value.split(/\s+/);
+                            await this.plugin.savePluginData();
+                        });
+                    })
+            );
+
+        new Setting(containerEl)
+            .setName(t("FRONTMATTER_NAME"))
+            .setDesc(t("FRONTMATTER_NAME_DESC"))
+            .addTextArea((text) =>
+                text
+                    .setValue(this.plugin.data.settings.reviewFrontmatter.join(" "))
+                    .onChange((value) => {
+                        applySettingsUpdate(async () => {
+                            this.plugin.data.settings.reviewFrontmatter = value.split(/\s+/);
                             await this.plugin.savePluginData();
                         });
                     })


### PR DESCRIPTION
I share notes with several friends, that we all want to review as flashcards, but this isn't possible since the information for storing the review data is shared.

I have added an option to the settings where you can add an addition to the frontmatter, for example the users name.

If I set the option to `-simon` then the frontmatter used will be:

```
sr-due-simon: 2023-01-17
sr-interval-simon: 1
sr-ease-simon: 160
```

Then another user can have their option set to `-mary`, and have their own set of information in the frontmatter, so they can review notes separately.

The change is fairly minimal, I've just added the addition to the instances in the code where the frontmatter text is used.

If you'd like to add this to the plugin let me know, and I can add the settings text to the different languages.