### PR TITLE
Fix issue requiring collapseIcon to be clicked twice to expand/collapsed deck tree

### DIFF
--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -843,13 +843,13 @@ export class Deck {
         );
         const shouldBeInitiallyExpanded: boolean =
             modal.plugin.data.settings.initiallyExpandAllSubdecksInTree;
-        let collapsed = shouldBeInitiallyExpanded;
+        let collapsed = !shouldBeInitiallyExpanded;
         let collapseIconEl: HTMLElement | null = null;
         if (this.subdecks.length > 0) {
             collapseIconEl = deckViewSelf.createDiv("tree-item-icon collapse-icon");
             collapseIconEl.innerHTML = COLLAPSE_ICON;
             (collapseIconEl.childNodes[0] as HTMLElement).style.transform =
-                shouldBeInitiallyExpanded ? "" : "rotate(-90deg)";
+                collapsed ? "rotate(-90deg)" : "";
         }
 
         const deckViewInner: HTMLElement = deckViewSelf.createDiv("tree-item-inner");
@@ -887,7 +887,7 @@ export class Deck {
         );
 
         const deckViewChildren: HTMLElement = deckView.createDiv("tree-item-children");
-        deckViewChildren.style.display = shouldBeInitiallyExpanded ? "block" : "none";
+        deckViewChildren.style.display = collapsed ? "none" : "block";
         if (this.subdecks.length > 0) {
             collapseIconEl.addEventListener("click", () => {
                 if (collapsed) {

--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -848,8 +848,9 @@ export class Deck {
         if (this.subdecks.length > 0) {
             collapseIconEl = deckViewSelf.createDiv("tree-item-icon collapse-icon");
             collapseIconEl.innerHTML = COLLAPSE_ICON;
-            (collapseIconEl.childNodes[0] as HTMLElement).style.transform =
-                collapsed ? "rotate(-90deg)" : "";
+            (collapseIconEl.childNodes[0] as HTMLElement).style.transform = collapsed
+                ? "rotate(-90deg)"
+                : "";
         }
 
         const deckViewInner: HTMLElement = deckViewSelf.createDiv("tree-item-inner");


### PR DESCRIPTION
Closes #655

The problem is that the initial value of `collapsed` was being set to the `shouldBeInitiallyExpanded` config value, even though these booleans should be opposite (collapsed vs. expanded).

Because the initial UI was set from `shouldBeInitiallyExpanded`, but the callback to the click event checked `collapsed`, the first click would make no visual change, but merely set the `collapsed` variable to be correct, and the second click would work as expected.

Technically only the  change on line `846` is necessary, but the other two changes prevent the same visual confusion from occurring in the future by ensuring that that the UI and `collapsed` are in sync.