### PR TITLE
Close very old issues (>= 1 year)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Close Stale Issues & PRs
+
+permissions:
+    contents: write
+    issues: write
+    pull-requests: write
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 4 * * 0"
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/stale@v4.1.1
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  days-before-issue-stale: 365
+                  days-before-issue-close: 30
+                  days-before-pr-stale: 365
+                  days-before-pr-close: 30
+                  stale-issue-label: "stale"
+                  stale-pr-label: "stale"
+                  operations-per-run: 256
+                  delete-branch: true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ and this project (sorta) adheres to [Semantic Versioning](https://semver.org/spe
 
 ### Changed
 
+-   Close very old issues (>= 1 year)
 -   Update Russian translation ([mikkovedru](https://github.com/mikkovedru))
 
 ### Fixed


### PR DESCRIPTION
Issue/PR marked as stale after 1 year of inactivity, closed if it sees no activity for 30 days.