### PR TITLE
remove skip after modifying card text

### DIFF
--- a/src/flashcard-modal.tsx
+++ b/src/flashcard-modal.tsx
@@ -410,7 +410,6 @@ export class FlashcardModal extends Modal {
         await this.app.vault.modify(this.currentCard.note, fileText);
         this.currentDeck.deleteFlashcardAtIndex(this.currentCardIdx, this.currentCard.isDue);
         this.burySiblingCards(false);
-        this.currentDeck.nextCard(this);
     }
 
     private showAnswer(): void {


### PR DESCRIPTION
As discussed in #630 , the skip after modifying a card is not a good design choice. I removed the line.