### PR TITLE
Remove the spaces before and after the question marks in the multi-line basic flashcards

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,12 +1,4 @@
-// import { CardType } from "src/scheduling";
-
-export enum CardType {
-    SingleLineBasic,
-    SingleLineReversed,
-    MultiLineBasic,
-    MultiLineReversed,
-    Cloze,
-}
+import { CardType } from "src/scheduling";
 
 /**
  * Returns flashcards found in `text`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,12 @@
-import { CardType } from "src/scheduling";
+// import { CardType } from "src/scheduling";
+
+export enum CardType {
+    SingleLineBasic,
+    SingleLineReversed,
+    MultiLineBasic,
+    MultiLineReversed,
+    Cloze,
+}
 
 /**
  * Returns flashcards found in `text`
@@ -27,7 +35,8 @@ export function parse(
 
     const lines: string[] = text.replaceAll("\r\n", "\n").split("\n");
     for (let i = 0; i < lines.length; i++) {
-        if (lines[i].length === 0) {
+        const currentLine = lines[i];
+        if (currentLine.length === 0) {
             if (cardType) {
                 cards.push([cardType, cardText, lineNo]);
                 cardType = null;
@@ -35,8 +44,8 @@ export function parse(
 
             cardText = "";
             continue;
-        } else if (lines[i].startsWith("<!--") && !lines[i].startsWith("<!--SR:")) {
-            while (i + 1 < lines.length && !lines[i].includes("-->")) i++;
+        } else if (currentLine.startsWith("<!--") && !currentLine.startsWith("<!--SR:")) {
+            while (i + 1 < lines.length && !currentLine.includes("-->")) i++;
             i++;
             continue;
         }
@@ -44,11 +53,11 @@ export function parse(
         if (cardText.length > 0) {
             cardText += "\n";
         }
-        cardText += lines[i];
+        cardText += currentLine.trim();
 
         if (
-            lines[i].includes(singlelineReversedCardSeparator) ||
-            lines[i].includes(singlelineCardSeparator)
+            currentLine.includes(singlelineReversedCardSeparator) ||
+            currentLine.includes(singlelineCardSeparator)
         ) {
             cardType = lines[i].includes(singlelineReversedCardSeparator)
                 ? CardType.SingleLineReversed
@@ -64,20 +73,20 @@ export function parse(
             cardText = "";
         } else if (
             cardType === null &&
-            ((convertHighlightsToClozes && /==.*?==/gm.test(lines[i])) ||
-                (convertBoldTextToClozes && /\*\*.*?\*\*/gm.test(lines[i])) ||
-                (convertCurlyBracketsToClozes && /{{.*?}}/gm.test(lines[i])))
+            ((convertHighlightsToClozes && /==.*?==/gm.test(currentLine)) ||
+                (convertBoldTextToClozes && /\*\*.*?\*\*/gm.test(currentLine)) ||
+                (convertCurlyBracketsToClozes && /{{.*?}}/gm.test(currentLine)))
         ) {
             cardType = CardType.Cloze;
             lineNo = i;
-        } else if (lines[i] === multilineCardSeparator) {
+        } else if (currentLine.trim() === multilineCardSeparator) {
             cardType = CardType.MultiLineBasic;
             lineNo = i;
-        } else if (lines[i] === multilineReversedCardSeparator) {
+        } else if (currentLine.trim() === multilineReversedCardSeparator) {
             cardType = CardType.MultiLineReversed;
             lineNo = i;
-        } else if (lines[i].startsWith("```") || lines[i].startsWith("~~~")) {
-            const codeBlockClose = lines[i].match(/`+|~+/)[0];
+        } else if (currentLine.startsWith("```") || currentLine.startsWith("~~~")) {
+            const codeBlockClose = currentLine.match(/`+|~+/)[0];
             while (i + 1 < lines.length && !lines[i + 1].startsWith(codeBlockClose)) {
                 i++;
                 cardText += "\n" + lines[i];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -45,7 +45,7 @@ export function parse(
         if (cardText.length > 0) {
             cardText += "\n";
         }
-        cardText += currentLine.trim();
+        cardText += currentLine.trimEnd();
 
         if (
             currentLine.includes(singlelineReversedCardSeparator) ||

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -47,13 +47,7 @@ test("Test parsing of multi line basic cards", () => {
     expect(parse("Question\n?\nAnswer", ...defaultArgs)).toEqual([
         [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
     ]);
-    expect(parse("Question\n ?\nAnswer", ...defaultArgs)).toEqual([
-        [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
-    ]);
     expect(parse("Question\n? \nAnswer", ...defaultArgs)).toEqual([
-        [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
-    ]);
-    expect(parse("Question\n ? \nAnswer", ...defaultArgs)).toEqual([
         [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
     ]);
     expect(parse("Question\n?\nAnswer <!--SR:!2021-08-11,4,270-->", ...defaultArgs)).toEqual([

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -47,6 +47,15 @@ test("Test parsing of multi line basic cards", () => {
     expect(parse("Question\n?\nAnswer", ...defaultArgs)).toEqual([
         [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
     ]);
+    expect(parse("Question\n ?\nAnswer", ...defaultArgs)).toEqual([
+        [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
+    ]);
+    expect(parse("Question\n? \nAnswer", ...defaultArgs)).toEqual([
+        [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
+    ]);
+    expect(parse("Question\n ? \nAnswer", ...defaultArgs)).toEqual([
+        [CardType.MultiLineBasic, "Question\n?\nAnswer", 1],
+    ]);
     expect(parse("Question\n?\nAnswer <!--SR:!2021-08-11,4,270-->", ...defaultArgs)).toEqual([
         [CardType.MultiLineBasic, "Question\n?\nAnswer <!--SR:!2021-08-11,4,270-->", 1],
     ]);


### PR DESCRIPTION
Fixed issue mentioned here: #690. 

**Changes:** 
- Defined `currentLine` variable in the beginning of the main cycle in `src/parser.ts` 
- Used `trim()` to remove the extra spaces when appending `cardText`
- Used `trim()` to clean the line before comparing with separator symbol 
