### PR TITLE
IOS Phone screen fix

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,3 +155,16 @@
         width: 100px;
     }
 }
+
+@media only screen and (orientation: portrait) {
+
+    .modal {
+    
+    margin-top: 20%;
+    
+    width: 100% !important;
+
+    height: 80% !important;
+    
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -157,14 +157,9 @@
 }
 
 @media only screen and (orientation: portrait) {
-
     .modal {
-    
     margin-top: 20%;
-    
     width: 100% !important;
-
-    height: 80% !important;
-    
+    height: 80%;
     }
 }


### PR DESCRIPTION
a fix for phone screens as I encountered a very broken view when trying to see the flashcards on a phone (see pictures).

This fixes the displayproblem with ios devices. On android phones this bug doesn't seem to appear. BUT this also changes how much of the display is taken up. Because on PC not the whole vertical space is taken I also made a bit of space above and below.


How it looks on android with the Fix:
![Screenshot_20231101_202441_md obsidian](https://github.com/st3v3nmw/obsidian-spaced-repetition/assets/71901885/264c61cd-8d19-4674-8458-1b5f3924a41c)



Picure of the problem on IOS

without a Theme:
![IMG_0136](https://github.com/st3v3nmw/obsidian-spaced-repetition/assets/71901885/b6f07b97-14ce-44db-b596-e390dce91375)

with a Theme (better visible 😇 )
![IMG_0135](https://github.com/st3v3nmw/obsidian-spaced-repetition/assets/71901885/391e969c-d16f-4f9b-920c-3bf603383e9b)

looks of the Fix:
![IMG_0137](https://github.com/st3v3nmw/obsidian-spaced-repetition/assets/71901885/87510735-32c1-474a-8cf9-1d91f942853e)