### PR TITLE
[BUG] Static method findAndReplace leads to failure if the lineNo is 0 instead of null #828

### DIFF
--- a/src/util/MultiLineTextFinder.ts
+++ b/src/util/MultiLineTextFinder.ts
@@ -12,8 +12,11 @@ export class MultiLineTextFinder {
         } else {
             const sourceTextArray = splitTextIntoLineArray(sourceText);
             const searchTextArray = splitTextIntoLineArray(searchText);
-            const lineNo: number = MultiLineTextFinder.find(sourceTextArray, searchTextArray);
-            if (lineNo) {
+            const lineNo: number | null = MultiLineTextFinder.find(
+                sourceTextArray,
+                searchTextArray,
+            );
+            if (lineNo !== null) {
                 const replacementTextArray = splitTextIntoLineArray(replacementText);
                 const linesToRemove: number = searchTextArray.length;
                 sourceTextArray.splice(lineNo, linesToRemove, ...replacementTextArray);


### PR DESCRIPTION
Fixes #828 