### PR TITLE
fix: Refresh flashcard modal after edit and general QOL improvements to editing

### DIFF
--- a/src/FlashcardReviewSequencer.ts
+++ b/src/FlashcardReviewSequencer.ts
@@ -217,15 +217,15 @@ export class FlashcardReviewSequencer implements IFlashcardReviewSequencer {
         const cardFrontBackList: CardFrontBack[] = CardFrontBackUtil.expand(
             question.questionType,
             question.questionText.actualQuestion,
-            this.settings
-        )
+            this.settings,
+        );
 
         await this.currentQuestion.writeQuestion(this.settings);
-        
+
         question.cards.forEach((card, i) => {
             const { front, back } = cardFrontBackList[i];
             card.front = front;
             card.back = back;
-        })
+        });
     }
 }

--- a/src/gui/FlashcardModal.tsx
+++ b/src/gui/FlashcardModal.tsx
@@ -14,6 +14,7 @@ import {
 import { FlashcardEditModal } from "./EditModal";
 import { DeckListView } from "./DeckListView";
 import { FlashcardReviewView } from "./FlashcardReviewView";
+import { CardFrontBack, CardFrontBackUtil } from "src/QuestionType";
 
 export enum FlashcardModalMode {
     DecksList,
@@ -121,7 +122,8 @@ export class FlashcardModal extends Modal {
         const editModal = FlashcardEditModal.Prompt(this.app, textPrompt);
         editModal
             .then(async (modifiedCardText) => {
-                this.reviewSequencer.updateCurrentQuestionText(modifiedCardText);
+                await this.reviewSequencer.updateCurrentQuestionTextAndCards(modifiedCardText);
+                this.flashcardView.rerenderCardContents()
             })
             .catch((reason) => console.log(reason));
     }

--- a/src/gui/FlashcardModal.tsx
+++ b/src/gui/FlashcardModal.tsx
@@ -123,7 +123,7 @@ export class FlashcardModal extends Modal {
         editModal
             .then(async (modifiedCardText) => {
                 await this.reviewSequencer.updateCurrentQuestionTextAndCards(modifiedCardText);
-                this.flashcardView.rerenderCardContents()
+                this.flashcardView.rerenderCardContents();
             })
             .catch((reason) => console.log(reason));
     }

--- a/src/gui/FlashcardModal.tsx
+++ b/src/gui/FlashcardModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, App } from "obsidian";
+import { Modal, App, Notice } from "obsidian";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import h from "vhtml";
 
@@ -8,13 +8,14 @@ import { SRSettings } from "src/settings";
 import { Deck } from "../Deck";
 import { Question } from "../Question";
 import {
+    CardFrontBackMissingError,
+    CardLengthMismatchError,
     FlashcardReviewMode,
     IFlashcardReviewSequencer as IFlashcardReviewSequencer,
 } from "src/FlashcardReviewSequencer";
 import { FlashcardEditModal } from "./EditModal";
 import { DeckListView } from "./DeckListView";
 import { FlashcardReviewView } from "./FlashcardReviewView";
-import { CardFrontBack, CardFrontBackUtil } from "src/QuestionType";
 
 export enum FlashcardModalMode {
     DecksList,
@@ -125,6 +126,15 @@ export class FlashcardModal extends Modal {
                 await this.reviewSequencer.updateCurrentQuestionTextAndCards(modifiedCardText);
                 this.flashcardView.rerenderCardContents();
             })
-            .catch((reason) => console.log(reason));
+            .catch((reason) => {
+                if (reason instanceof CardLengthMismatchError) {
+                    new Notice(
+                        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+                    );
+                } else if (reason instanceof CardFrontBackMissingError) {
+                    new Notice("Unable to update flashcard. Missing front or back side of card.");
+                }
+                console.log(reason);
+            });
     }
 }

--- a/src/gui/FlashcardModal.tsx
+++ b/src/gui/FlashcardModal.tsx
@@ -16,6 +16,7 @@ import {
 import { FlashcardEditModal } from "./EditModal";
 import { DeckListView } from "./DeckListView";
 import { FlashcardReviewView } from "./FlashcardReviewView";
+import { t } from "src/lang/helpers";
 
 export enum FlashcardModalMode {
     DecksList,
@@ -128,11 +129,9 @@ export class FlashcardModal extends Modal {
             })
             .catch((reason) => {
                 if (reason instanceof CardLengthMismatchError) {
-                    new Notice(
-                        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
-                    );
+                    new Notice(t("CARD_LENGTH_MISMATCH_NOTICE"));
                 } else if (reason instanceof CardFrontBackMissingError) {
-                    new Notice("Unable to update flashcard. Missing front or back side of card.");
+                    new Notice(t("CARD_FRONT_BACK_MISSING_NOTICE"));
                 }
                 console.log(reason);
             });

--- a/src/gui/FlashcardReviewView.tsx
+++ b/src/gui/FlashcardReviewView.tsx
@@ -164,7 +164,7 @@ export class FlashcardReviewView {
         const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
             this.app,
             this.plugin,
-            this._currentNote.filePath
+            this._currentNote.filePath,
         );
         await wrapper.renderMarkdownWrapper(this._currentCard.front, this.content);
     }
@@ -341,7 +341,7 @@ export class FlashcardReviewView {
         const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
             this.app,
             this.plugin,
-            this._currentNote.filePath
+            this._currentNote.filePath,
         );
         wrapper.renderMarkdownWrapper(this._currentCard.back, this.content);
     }

--- a/src/gui/FlashcardReviewView.tsx
+++ b/src/gui/FlashcardReviewView.tsx
@@ -131,12 +131,7 @@ export class FlashcardReviewView {
 
         // Setup card content
         this.content.empty();
-        const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
-            this.app,
-            this.plugin,
-            this._currentNote.filePath,
-        );
-        await wrapper.renderMarkdownWrapper(this._currentCard.front, this.content);
+        await this._renderMarkdownFront();
 
         // Setup response buttons
         this._resetResponseButtons();
@@ -148,6 +143,30 @@ export class FlashcardReviewView {
         this.view.removeClass("sr-is-hidden");
         this.backButton.removeClass("sr-is-hidden");
         document.addEventListener("keydown", this._keydownHandler);
+    }
+
+    /**
+     * If the card is already being shown, re-render just the Markdown
+     * contents if needed
+     */
+    async rerenderCardContents() {
+        this.content.empty();
+        this._renderMarkdownFront();
+        if (this.mode == FlashcardModalMode.Back) {
+            this._renderMarkdownBackAndDivider();
+        }
+    }
+
+    /**
+     * Set up the Markdown rendering for the card's front side
+     */
+    private async _renderMarkdownFront() {
+        const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
+            this.app,
+            this.plugin,
+            this._currentNote.filePath
+        );
+        await wrapper.renderMarkdownWrapper(this._currentCard.front, this.content);
     }
 
     /**
@@ -276,21 +295,7 @@ export class FlashcardReviewView {
 
         this.resetButton.disabled = false;
 
-        // Show answer text
-        if (this._currentQuestion.questionType !== CardType.Cloze) {
-            const hr: HTMLElement = document.createElement("hr");
-            hr.addClass("sr-card-divide");
-            this.content.appendChild(hr);
-        } else {
-            this.content.empty();
-        }
-
-        const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
-            this.app,
-            this.plugin,
-            this._currentNote.filePath,
-        );
-        wrapper.renderMarkdownWrapper(this._currentCard.back, this.content);
+        this._renderMarkdownBackAndDivider();
 
         // Show response buttons
         this.answerButton.addClass("sr-is-hidden");
@@ -319,6 +324,26 @@ export class FlashcardReviewView {
                 ReviewResponse.Easy,
             );
         }
+    }
+
+    /**
+     * Setup Markdown rendering for the card's back side and the divider
+     */
+    private _renderMarkdownBackAndDivider() {
+        if (this._currentQuestion.questionType !== CardType.Cloze) {
+            const hr: HTMLElement = document.createElement("hr");
+            hr.addClass("sr-card-divide");
+            this.content.appendChild(hr);
+        } else {
+            this.content.empty();
+        }
+
+        const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
+            this.app,
+            this.plugin,
+            this._currentNote.filePath
+        );
+        wrapper.renderMarkdownWrapper(this._currentCard.back, this.content);
     }
 
     private async _processReview(response: ReviewResponse): Promise<void> {

--- a/src/lang/locale/ar.ts
+++ b/src/lang/locale/ar.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: ":السهولة الحالية",
     CURRENT_INTERVAL_HELP_TEXT: ":الفاصل الزمني الحالي",
     CARD_GENERATED_FROM: "${notePath} :تم إنشاؤها من",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "افتح الملاحظة للمراجعة",

--- a/src/lang/locale/cz.ts
+++ b/src/lang/locale/cz.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Current Ease: ",
     CURRENT_INTERVAL_HELP_TEXT: "Current Interval: ",
     CARD_GENERATED_FROM: "Generated from: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Otevřít poznámku k revizi",

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -24,6 +24,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Aktuelle Schwierigkeit: ",
     CURRENT_INTERVAL_HELP_TEXT: "Aktueller Intervall: ",
     CARD_GENERATED_FROM: "Erstellt von: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Notiz zur Wiederholung öffnen",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Current Ease: ",
     CURRENT_INTERVAL_HELP_TEXT: "Current Interval: ",
     CARD_GENERATED_FROM: "Generated from: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Open a note for review",

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Facilidad Actual: ",
     CURRENT_INTERVAL_HELP_TEXT: "Intervalo Actual: ",
     CARD_GENERATED_FROM: "Generado Desde: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Abrir nota para revisión",

--- a/src/lang/locale/it.ts
+++ b/src/lang/locale/it.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Difficoltà attuale: ",
     CURRENT_INTERVAL_HELP_TEXT: "Intervallo attuale: ",
     CARD_GENERATED_FROM: "Generato da: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Apri una nota per rivisita",

--- a/src/lang/locale/ja.ts
+++ b/src/lang/locale/ja.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Current Ease: ",
     CURRENT_INTERVAL_HELP_TEXT: "Current Interval: ",
     CARD_GENERATED_FROM: "Generated from: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "レビューするノートを開く",

--- a/src/lang/locale/ko.ts
+++ b/src/lang/locale/ko.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Current Ease: ",
     CURRENT_INTERVAL_HELP_TEXT: "Current Interval: ",
     CARD_GENERATED_FROM: "Generated from: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "리뷰할 노트 열기",

--- a/src/lang/locale/pl.ts
+++ b/src/lang/locale/pl.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Aktualna łatwość: ",
     CURRENT_INTERVAL_HELP_TEXT: "Aktualny interwał: ",
     CARD_GENERATED_FROM: "Wygenerowano z: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Otwórz notatkę do przeglądu",

--- a/src/lang/locale/pt-br.ts
+++ b/src/lang/locale/pt-br.ts
@@ -22,6 +22,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Facilidade atual: ",
     CURRENT_INTERVAL_HELP_TEXT: "Intervalo atual: ",
     CARD_GENERATED_FROM: "Gerada a partir de: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Abrir uma nota para revisar",

--- a/src/lang/locale/ru.ts
+++ b/src/lang/locale/ru.ts
@@ -30,6 +30,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Текущий прогресс: ",
     CURRENT_INTERVAL_HELP_TEXT: "Текущий интервал: ",
     CARD_GENERATED_FROM: "Сгенерированно из: ${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Открыть заметку для изучения",

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "目前掌握程度：",
     CURRENT_INTERVAL_HELP_TEXT: "目前间隔：",
     CARD_GENERATED_FROM: "生成自：${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "打开一个笔记开始复习",

--- a/src/lang/locale/zh-tw.ts
+++ b/src/lang/locale/zh-tw.ts
@@ -21,6 +21,9 @@ export default {
     CURRENT_EASE_HELP_TEXT: "目前掌握程度：",
     CURRENT_INTERVAL_HELP_TEXT: "目前間隔時間：",
     CARD_GENERATED_FROM: "生成自：${notePath}",
+    CARD_LENGTH_MISMATCH_NOTICE:
+        "Unable to update flashcard. The number of cards after the edit does not match the original number of cards.",
+    CARD_FRONT_BACK_MISSING_NOTICE: "Unable to update flashcard. The front or back is missing.",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "打開一個筆記開始復習",

--- a/tests/unit/FlashcardReviewSequencer.test.ts
+++ b/tests/unit/FlashcardReviewSequencer.test.ts
@@ -772,11 +772,16 @@ describe("updateCurrentQuestionTextAndCards", () => {
 <!--SR:!2023-09-02,4,270-->`;
                 let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer
 <!--SR:!2023-09-02,4,270-->`;
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `A much more in depth question`
+                let updatedBack = `A much more detailed answer`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text,
                     updatedQ,
                     originalStr,
                     updatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
             });
@@ -793,13 +798,19 @@ describe("updateCurrentQuestionTextAndCards", () => {
                 let originalStr: string = `#flashcards Q2::A2 <!--SR:!2023-09-02,4,270-->`;
                 let expectedUpdatedStr: string = `#flashcards A much more in depth question::A much more detailed answer
 <!--SR:!2023-09-02,4,270-->`;
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `A much more in depth question`
+                let updatedBack = `A much more detailed answer`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text,
                     updatedQ,
                     originalStr,
                     expectedUpdatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
+
             });
         });
 
@@ -818,13 +829,20 @@ describe("updateCurrentQuestionTextAndCards", () => {
                 let updatedQ: string = "A much more in depth question::A much more detailed answer";
                 let originalStr: string = `#flashcards Q2::A2 <!--SR:!2023-09-02,4,270-->`;
                 let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer <!--SR:!2023-09-02,4,270-->`;
-                await checkUpdateCurrentQuestionText(
+
+                let updatedFront = `A much more in depth question`
+                let updatedBack = `A much more detailed answer`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text1,
                     updatedQ,
                     originalStr,
                     updatedStr,
+                    updatedFront,
+                    updatedBack,
                     settings,
                 );
+
             });
 
             test("Question has schedule on following line (but placed on same line due to settings)", async () => {
@@ -840,13 +858,21 @@ describe("updateCurrentQuestionTextAndCards", () => {
                 let originalStr: string = `#flashcards Q2::A2
 <!--SR:!2023-09-02,4,270-->`;
                 let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer <!--SR:!2023-09-02,4,270-->`;
-                await checkUpdateCurrentQuestionText(
+
+                let updatedFront = "A much more in depth question"
+                let updatedBack = "A much more detailed answer"
+
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text,
                     updatedQ,
                     originalStr,
                     updatedStr,
+                    updatedFront,
+                    updatedBack,
                     settings,
                 );
+
             });
         });
 
@@ -877,13 +903,21 @@ A2 (answer now includes more detail)
 extra answer line 2
 <!--SR:!2023-09-02,4,270-->`;
 
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `Multiline question
+Question starting immediately after tag`
+                let updatedBack = `A2 (answer now includes more detail)
+extra answer line 2`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text,
                     updatedQ,
                     originalStr,
                     expectedUpdatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
+
             });
 
             test("Question starts on same line as tag (after two spaces); Existing schedule present", async () => {
@@ -912,13 +946,21 @@ A2 (answer now includes more detail)
 extra answer line 2
 <!--SR:!2023-09-02,4,270-->`;
 
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `Multiline question
+Question starting immediately after tag`
+                let updatedBack = `A2 (answer now includes more detail)
+extra answer line 2`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text,
                     updatedQ,
                     originalStr,
                     expectedUpdatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
+
             });
 
             test("Question starts line after tag; Existing schedule present", async () => {
@@ -949,13 +991,21 @@ A2 (answer now includes more detail)
 extra answer line 2
 <!--SR:!2023-09-02,4,270-->`;
 
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `Multiline question
+Question starting line after tag`
+                let updatedBack = `A2 (answer now includes more detail)
+extra answer line 2`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     text,
                     updatedQ,
                     originalStr,
                     expectedUpdatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
+
             });
 
             test("Question starts line after tag (no white space after tag); New card", async () => {
@@ -980,11 +1030,18 @@ extra answer line 2`;
                 let expectedUpdatedStr: string = `#flashcards
 ${updatedQuestionText}`;
 
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `Multiline question
+Question starting immediately after tag`;
+                let updatedBack = `A2 (answer now includes more detail)
+extra answer line 2`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     fileText,
                     updatedQuestionText,
                     originalQuestionStr,
                     expectedUpdatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
             });
@@ -1011,11 +1068,18 @@ extra answer line 2`;
                 let expectedUpdatedStr: string = `#flashcards
 ${updatedQuestionText}`;
 
-                await checkUpdateCurrentQuestionText(
+                let updatedFront = `Multiline question
+Question starting immediately after tag`
+                let updatedBack = `A2 (answer now includes more detail)
+extra answer line 2`
+
+                await checkUpdateCurrentQuestionTextAndCard(
                     fileText,
                     updatedQuestionText,
                     originalQuestionStr,
                     expectedUpdatedStr,
+                    updatedFront,
+                    updatedBack,
                     DEFAULT_SETTINGS,
                 );
             });
@@ -1113,12 +1177,16 @@ describe("Sequences", () => {
         let updatedQ: string = "A much more in depth question::A much more detailed answer";
         let originalStr: string = `#flashcards Q2::A2`;
         let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer`;
+        let updatedFront = 'A much more in depth question'
+        let updatedBack = 'A much more detailed answer'
 
-        let c: TestContext = await checkUpdateCurrentQuestionText(
+        let c: TestContext = await checkUpdateCurrentQuestionTextAndCard(
             text1,
             updatedQ,
             originalStr,
             updatedStr,
+            updatedFront,
+            updatedBack,
             DEFAULT_SETTINGS,
         );
 
@@ -1145,11 +1213,13 @@ function skipAndCheckNoRemainingCards(c: TestContext) {
     expect(c.reviewSequencer.hasCurrentCard).toEqual(false);
 }
 
-async function checkUpdateCurrentQuestionText(
+async function checkUpdateCurrentQuestionTextAndCard(
     noteText: string,
     updatedQ: string,
     originalStr: string,
     updatedStr: string,
+    updatedFront: string,
+    updatedBack: string,
     settings: SRSettings,
 ): Promise<TestContext> {
     let c: TestContext = TestContext.Create(
@@ -1167,5 +1237,9 @@ async function checkUpdateCurrentQuestionText(
     if (!c.originalText.includes(originalStr)) throw `Text not found: ${originalStr}`;
     let expectedFileText: string = c.originalText.replace(originalStr, updatedStr);
     expect(await c.file.read()).toEqual(expectedFileText);
+
+    expect(c.reviewSequencer.currentCard.front).toStrictEqual(updatedFront);
+    expect(c.reviewSequencer.currentCard.back).toStrictEqual(updatedBack);
+
     return c;
 }

--- a/tests/unit/FlashcardReviewSequencer.test.ts
+++ b/tests/unit/FlashcardReviewSequencer.test.ts
@@ -772,8 +772,8 @@ describe("updateCurrentQuestionTextAndCards", () => {
 <!--SR:!2023-09-02,4,270-->`;
                 let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer
 <!--SR:!2023-09-02,4,270-->`;
-                let updatedFront = `A much more in depth question`
-                let updatedBack = `A much more detailed answer`
+                let updatedFront = `A much more in depth question`;
+                let updatedBack = `A much more detailed answer`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text,
@@ -798,8 +798,8 @@ describe("updateCurrentQuestionTextAndCards", () => {
                 let originalStr: string = `#flashcards Q2::A2 <!--SR:!2023-09-02,4,270-->`;
                 let expectedUpdatedStr: string = `#flashcards A much more in depth question::A much more detailed answer
 <!--SR:!2023-09-02,4,270-->`;
-                let updatedFront = `A much more in depth question`
-                let updatedBack = `A much more detailed answer`
+                let updatedFront = `A much more in depth question`;
+                let updatedBack = `A much more detailed answer`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text,
@@ -810,7 +810,6 @@ describe("updateCurrentQuestionTextAndCards", () => {
                     updatedBack,
                     DEFAULT_SETTINGS,
                 );
-
             });
         });
 
@@ -830,8 +829,8 @@ describe("updateCurrentQuestionTextAndCards", () => {
                 let originalStr: string = `#flashcards Q2::A2 <!--SR:!2023-09-02,4,270-->`;
                 let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer <!--SR:!2023-09-02,4,270-->`;
 
-                let updatedFront = `A much more in depth question`
-                let updatedBack = `A much more detailed answer`
+                let updatedFront = `A much more in depth question`;
+                let updatedBack = `A much more detailed answer`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text1,
@@ -842,7 +841,6 @@ describe("updateCurrentQuestionTextAndCards", () => {
                     updatedBack,
                     settings,
                 );
-
             });
 
             test("Question has schedule on following line (but placed on same line due to settings)", async () => {
@@ -859,9 +857,8 @@ describe("updateCurrentQuestionTextAndCards", () => {
 <!--SR:!2023-09-02,4,270-->`;
                 let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer <!--SR:!2023-09-02,4,270-->`;
 
-                let updatedFront = "A much more in depth question"
-                let updatedBack = "A much more detailed answer"
-
+                let updatedFront = "A much more in depth question";
+                let updatedBack = "A much more detailed answer";
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text,
@@ -872,7 +869,6 @@ describe("updateCurrentQuestionTextAndCards", () => {
                     updatedBack,
                     settings,
                 );
-
             });
         });
 
@@ -904,9 +900,9 @@ extra answer line 2
 <!--SR:!2023-09-02,4,270-->`;
 
                 let updatedFront = `Multiline question
-Question starting immediately after tag`
+Question starting immediately after tag`;
                 let updatedBack = `A2 (answer now includes more detail)
-extra answer line 2`
+extra answer line 2`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text,
@@ -917,7 +913,6 @@ extra answer line 2`
                     updatedBack,
                     DEFAULT_SETTINGS,
                 );
-
             });
 
             test("Question starts on same line as tag (after two spaces); Existing schedule present", async () => {
@@ -947,9 +942,9 @@ extra answer line 2
 <!--SR:!2023-09-02,4,270-->`;
 
                 let updatedFront = `Multiline question
-Question starting immediately after tag`
+Question starting immediately after tag`;
                 let updatedBack = `A2 (answer now includes more detail)
-extra answer line 2`
+extra answer line 2`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text,
@@ -960,7 +955,6 @@ extra answer line 2`
                     updatedBack,
                     DEFAULT_SETTINGS,
                 );
-
             });
 
             test("Question starts line after tag; Existing schedule present", async () => {
@@ -992,9 +986,9 @@ extra answer line 2
 <!--SR:!2023-09-02,4,270-->`;
 
                 let updatedFront = `Multiline question
-Question starting line after tag`
+Question starting line after tag`;
                 let updatedBack = `A2 (answer now includes more detail)
-extra answer line 2`
+extra answer line 2`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     text,
@@ -1005,7 +999,6 @@ extra answer line 2`
                     updatedBack,
                     DEFAULT_SETTINGS,
                 );
-
             });
 
             test("Question starts line after tag (no white space after tag); New card", async () => {
@@ -1033,7 +1026,7 @@ ${updatedQuestionText}`;
                 let updatedFront = `Multiline question
 Question starting immediately after tag`;
                 let updatedBack = `A2 (answer now includes more detail)
-extra answer line 2`
+extra answer line 2`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     fileText,
@@ -1069,9 +1062,9 @@ extra answer line 2`;
 ${updatedQuestionText}`;
 
                 let updatedFront = `Multiline question
-Question starting immediately after tag`
+Question starting immediately after tag`;
                 let updatedBack = `A2 (answer now includes more detail)
-extra answer line 2`
+extra answer line 2`;
 
                 await checkUpdateCurrentQuestionTextAndCard(
                     fileText,
@@ -1177,8 +1170,8 @@ describe("Sequences", () => {
         let updatedQ: string = "A much more in depth question::A much more detailed answer";
         let originalStr: string = `#flashcards Q2::A2`;
         let updatedStr: string = `#flashcards A much more in depth question::A much more detailed answer`;
-        let updatedFront = 'A much more in depth question'
-        let updatedBack = 'A much more detailed answer'
+        let updatedFront = "A much more in depth question";
+        let updatedBack = "A much more detailed answer";
 
         let c: TestContext = await checkUpdateCurrentQuestionTextAndCard(
             text1,

--- a/tests/unit/FlashcardReviewSequencer.test.ts
+++ b/tests/unit/FlashcardReviewSequencer.test.ts
@@ -753,7 +753,7 @@ ${indent}- bar?::baz
     });
 });
 
-describe("updateCurrentQuestionText", () => {
+describe("updateCurrentQuestionTextAndCards", () => {
     let space: string = " ";
 
     describe("Checking update to file", () => {
@@ -1161,7 +1161,7 @@ async function checkUpdateCurrentQuestionText(
     await c.setSequencerDeckTreeFromOriginalText();
     expect(c.reviewSequencer.currentCard.front).toEqual("Q2");
 
-    await c.reviewSequencer.updateCurrentQuestionText(updatedQ);
+    await c.reviewSequencer.updateCurrentQuestionTextAndCards(updatedQ);
 
     // originalText should remain the same except for the specific substring change from originalStr => updatedStr
     if (!c.originalText.includes(originalStr)) throw `Text not found: ${originalStr}`;


### PR DESCRIPTION
## Description

This PR addresses #718, #686 by updating the card and review modal after a card is edited.

I also added handling of edge cases where the front/back of a card is missing after the edit, or the number of Cloze cards is different. This was needed for my fix, but I'd be happy to try another approach; just let me know.

## Screenshots of Notices

<img width="599" alt="Screenshot 2024-07-03 at 15 43 25" src="https://github.com/st3v3nmw/obsidian-spaced-repetition/assets/34608561/c436a37a-141a-4875-962e-373926bd23fb">

This notice displays if the front or back side is missing after an edit (e.g. the entire card is deleted by accident).

<img width="599" alt="Screenshot 2024-07-03 at 15 43 44" src="https://github.com/st3v3nmw/obsidian-spaced-repetition/assets/34608561/d9ea8a55-8939-48e1-8b42-cff230b9a85a">

This one displays if the number of Cloze cards changes.
