### PR TITLE
fix: parsing code blocks & custom separators

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-st3v3n.mw@gmail.com.
+mail@stephenmwangi.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/src/algorithms/base/srs-algorithm.ts
+++ b/src/algorithms/base/srs-algorithm.ts
@@ -5,7 +5,7 @@ export class SrsAlgorithm {
 
     public static getInstance(): ISrsAlgorithm {
         if (!SrsAlgorithm.instance) {
-            throw Error("there is no SrsAlgorithm instance.");
+            throw new Error("there is no SrsAlgorithm instance.");
         }
         return SrsAlgorithm.instance;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,6 @@
 export const SCHEDULING_INFO_REGEX =
     /^---\r?\n((?:.*\r?\n)*)sr-due: (.+)\r?\nsr-interval: (\d+)\r?\nsr-ease: (\d+)\r?\n((?:.*\r?\n)?)---/;
 export const YAML_FRONT_MATTER_REGEX = /^---\r?\n((?:.*\r?\n)*?)---/;
-export const NON_LETTER_SYMBOLS_REGEX = /[!-/:-@[-`{-~}\s]/g;
 
 export const MULTI_SCHEDULING_EXTRACTOR = /!([\d-]+),(\d+),(\d+)/gm;
 export const LEGACY_SCHEDULING_EXTRACTOR = /<!--SR:([\d-]+),(\d+),(\d+)-->/gm;

--- a/src/data-store-algorithm/data-store-algorithm.ts
+++ b/src/data-store-algorithm/data-store-algorithm.ts
@@ -5,7 +5,7 @@ export class DataStoreAlgorithm {
 
     public static getInstance(): IDataStoreAlgorithm {
         if (!DataStoreAlgorithm.instance) {
-            throw Error("there is no DataStoreAlgorithm instance.");
+            throw new Error("there is no DataStoreAlgorithm instance.");
         }
         return DataStoreAlgorithm.instance;
     }

--- a/src/data-stores/base/data-store.ts
+++ b/src/data-stores/base/data-store.ts
@@ -17,7 +17,7 @@ export class DataStore {
 
     public static getInstance(): IDataStore {
         if (!DataStore.instance) {
-            throw Error("there is no DataStore instance.");
+            throw new Error("there is no DataStore instance.");
         }
         return DataStore.instance;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -76,31 +76,32 @@ export function generateParser(options: ParserOptions): Parser {
 
 function generateGrammar(options: ParserOptions): string {
     // Contains the grammar for cloze cards
-    let clozes_grammar = ""
+    let clozes_grammar = "";
 
     // An array contianing the types of cards enabled by the user
-    let card_rules_list: string[] = ['html_comment', 'tilde_code', 'backprime_code'];
+    const card_rules_list: string[] = ["html_comment", "tilde_code", "backprime_code"];
 
     // Include reversed inline flashcards rule only if the user provided a non-empty marker for reversed inline flashcards
-    if(options.singleLineCardSeparator.trim()!=="") card_rules_list.push('inline_rev_card');
+    if (options.singleLineCardSeparator.trim() !== "") card_rules_list.push("inline_rev_card");
 
     // Include inline flashcards rule only if the user provided a non-empty marker for inline flashcards
-    if(options.singleLineCardSeparator.trim()!=="") card_rules_list.push('inline_card');
+    if (options.singleLineCardSeparator.trim() !== "") card_rules_list.push("inline_card");
 
     // Include reversed multiline flashcards rule only if the user provided a non-empty marker for reversed multiline flashcards
-    if(options.multilineReversedCardSeparator.trim()!=="") card_rules_list.push('multiline_rev_card');
+    if (options.multilineReversedCardSeparator.trim() !== "")
+        card_rules_list.push("multiline_rev_card");
 
     // Include multiline flashcards rule only if the user provided a non-empty marker for multiline flashcards
-    if(options.multilineCardSeparator.trim()!=="") card_rules_list.push('multiline_card');
+    if (options.multilineCardSeparator.trim() !== "") card_rules_list.push("multiline_card");
 
     const cloze_rules_list: string[] = [];
     if (options.convertHighlightsToClozes) cloze_rules_list.push("cloze_equal");
     if (options.convertBoldTextToClozes) cloze_rules_list.push("cloze_star");
     if (options.convertCurlyBracketsToClozes) cloze_rules_list.push("cloze_bracket");
-        
+
     // Include cloze cards only if the user enabled at least one type of cloze cards
-    if(cloze_rules_list.length>0) {
-        card_rules_list.push('cloze_card');
+    if (cloze_rules_list.length > 0) {
+        card_rules_list.push("cloze_card");
         const cloze_rules = cloze_rules_list.join(" / ");
         clozes_grammar = `
 cloze_card
@@ -140,13 +141,13 @@ cloze_mark_bracket_open
 
 cloze_mark_bracket_close
 = "}}"
-` ;
+`;
     }
 
     // Important: we need to include `loose_line` rule to detect any other loose line.
     // Otherwise, we get a syntax error because the parser is likely not able to reach the end
     // of the file, as it may encounter loose lines, which it would not know how to handle.
-    card_rules_list.push('loose_line');
+    card_rules_list.push("loose_line");
 
     const card_rules = card_rules_list.join(" / ");
 

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -464,7 +464,22 @@ test("Test parsing of a mix of card types", () => {
 });
 
 test("Test parsing cards with codeblocks", () => {
-    // no blank lines
+    // `inline`
+    expect(
+        parse(
+            "my inline question containing `some inline code` in it::and this is answer possibly containing `inline` code.",
+            parserOptions,
+        ),
+    ).toEqual([
+        [
+            CardType.SingleLineBasic,
+            "my inline question containing `some inline code` in it::and this is answer possibly containing `inline` code.",
+            0,
+            0,
+        ],
+    ]);
+
+    // ```block```, no blank lines
     expect(
         parse(
             "How do you ... Python?\n?\n" +
@@ -481,7 +496,7 @@ test("Test parsing cards with codeblocks", () => {
         ],
     ]);
 
-    // with blank lines
+    // ```block```, with blank lines
     expect(
         parse(
             "How do you ... Python?\n?\n" +
@@ -498,7 +513,7 @@ test("Test parsing cards with codeblocks", () => {
         ],
     ]);
 
-    // general Markdown syntax
+    // nested markdown
     expect(
         parse(
             "Nested Markdown?\n?\n" +

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -75,6 +75,20 @@ test("Test parsing of single line basic cards", () => {
             convertCurlyBracketsToClozes: false,
         }),
     ).toEqual([[CardType.SingleLineBasic, "Question=Answer", 0, 0]]);
+
+    // empty string or whitespace character provided
+    expect(
+        parse("Question::Answer", {
+            singleLineCardSeparator: "",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([]);
 });
 
 test("Test parsing of single line reversed cards", () => {
@@ -103,6 +117,20 @@ test("Test parsing of single line reversed cards", () => {
             convertCurlyBracketsToClozes: false,
         }),
     ).toEqual([[CardType.SingleLineReversed, "Question&&&Answer", 0, 0]]);
+
+    // empty string or whitespace character provided
+    expect(
+        parse("Question:::Answer", {
+            singleLineCardSeparator: ">",
+            singleLineReversedCardSeparator: "  ",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([]);
 });
 
 test("Test parsing of multi line basic cards", () => {
@@ -199,6 +227,20 @@ test("Test parsing of multi line basic cards", () => {
             convertCurlyBracketsToClozes: false,
         }),
     ).toEqual([[CardType.MultiLineBasic, "Question\n@@\nAnswer", 0, 2]]);
+
+    // empty string or whitespace character provided
+    expect(
+        parse("Question\n?\nAnswer", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "\n",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([]);
 });
 
 test("Test parsing of multi line reversed cards", () => {
@@ -260,6 +302,20 @@ test("Test parsing of multi line reversed cards", () => {
             convertCurlyBracketsToClozes: false,
         }),
     ).toEqual([[CardType.MultiLineReversed, "Question\n@@@\nAnswer", 0, 2]]);
+
+    // empty string or whitespace character provided
+    expect(
+        parse("Question\n??\nAnswer", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "\t",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([]);
 });
 
 test("Test parsing of cloze cards", () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -15,12 +15,11 @@ const parserOptions: ParserOptions = {
 
 /**
  * This function is a small wrapper around parseEx used for testing only.
+ *  It generates a parser each time, overwriting the default one.
  * Created when the actual parser changed from returning [CardType, string, number, number] to ParsedQuestionInfo.
  * It's purpose is to minimise changes to all the test cases here during the parser()->parserEx() change.
  */
 function parse(text: string, options: ParserOptions): [CardType, string, number, number][] {
-    // for testing purposes, generate parser each time, overwriting the default one
-
     const list: ParsedQuestionInfo[] = parseEx(text, options);
     const result: [CardType, string, number, number][] = [];
     for (const item of list) {
@@ -30,6 +29,7 @@ function parse(text: string, options: ParserOptions): [CardType, string, number,
 }
 
 test("Test parsing of single line basic cards", () => {
+    // standard symbols
     expect(parse("Question::Answer", parserOptions)).toEqual([
         [CardType.SingleLineBasic, "Question::Answer", 0, 0],
     ]);
@@ -49,9 +49,36 @@ test("Test parsing of single line basic cards", () => {
     expect(parse("#flashcards/science Question ::Answer", parserOptions)).toEqual([
         [CardType.SingleLineBasic, "#flashcards/science Question ::Answer", 0, 0],
     ]);
+
+    // custom symbols
+    expect(
+        parse("Question&&Answer", {
+            singleLineCardSeparator: "&&",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([[CardType.SingleLineBasic, "Question&&Answer", 0, 0]]);
+    expect(
+        parse("Question=Answer", {
+            singleLineCardSeparator: "=",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([[CardType.SingleLineBasic, "Question=Answer", 0, 0]]);
 });
 
 test("Test parsing of single line reversed cards", () => {
+    // standard symbols
     expect(parse("Question:::Answer", parserOptions)).toEqual([
         [CardType.SingleLineReversed, "Question:::Answer", 0, 0],
     ]);
@@ -62,9 +89,24 @@ test("Test parsing of single line reversed cards", () => {
         [CardType.SingleLineReversed, "Q1:::A1", 2, 2],
         [CardType.SingleLineReversed, "Q2::: A2", 3, 3],
     ]);
+
+    // custom symbols
+    expect(
+        parse("Question&&&Answer", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: "&&&",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([[CardType.SingleLineReversed, "Question&&&Answer", 0, 0]]);
 });
 
 test("Test parsing of multi line basic cards", () => {
+    // standard symbols
     expect(parse("Question\n?\nAnswer", parserOptions)).toEqual([
         [CardType.MultiLineBasic, "Question\n?\nAnswer", 0, 2],
     ]);
@@ -84,12 +126,7 @@ test("Test parsing of multi line basic cards", () => {
         [CardType.MultiLineBasic, "Question\n?\nAnswer line 1\nAnswer line 2", 0, 3],
     ]);
     expect(parse("#Title\n\nLine0\nQ1\n?\nA1\nAnswerExtra\n\nQ2\n?\nA2", parserOptions)).toEqual([
-        [
-            CardType.MultiLineBasic,
-            "Line0\nQ1\n?\nA1\nAnswerExtra",
-            /* Line0 */ 2,
-            /* AnswerExtra */ 6,
-        ],
+        [CardType.MultiLineBasic, "Line0\nQ1\n?\nA1\nAnswerExtra", 2, 6],
         [CardType.MultiLineBasic, "Q2\n?\nA2", 8, 10],
     ]);
     expect(parse("#flashcards/tag-on-previous-line\nQuestion\n?\nAnswer", parserOptions)).toEqual([
@@ -148,9 +185,24 @@ test("Test parsing of multi line basic cards", () => {
             10,
         ],
     ]);
+
+    // custom symbols
+    expect(
+        parse("Question\n@@\nAnswer\n\nsfdg", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "@@",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([[CardType.MultiLineBasic, "Question\n@@\nAnswer", 0, 2]]);
 });
 
 test("Test parsing of multi line reversed cards", () => {
+    // standard symbols
     expect(parse("Question\n??\nAnswer", parserOptions)).toEqual([
         [CardType.MultiLineReversed, "Question\n??\nAnswer", 0, 2],
     ]);
@@ -161,12 +213,7 @@ test("Test parsing of multi line reversed cards", () => {
         [CardType.MultiLineReversed, "Question\n??\nAnswer line 1\nAnswer line 2", 0, 3],
     ]);
     expect(parse("#Title\n\nLine0\nQ1\n??\nA1\nAnswerExtra\n\nQ2\n??\nA2", parserOptions)).toEqual([
-        [
-            CardType.MultiLineReversed,
-            "Line0\nQ1\n??\nA1\nAnswerExtra",
-            /* Line0 */ 2,
-            /* AnswerExtra */ 6,
-        ],
+        [CardType.MultiLineReversed, "Line0\nQ1\n??\nA1\nAnswerExtra", 2, 6],
         [CardType.MultiLineReversed, "Q2\n??\nA2", 8, 10],
     ]);
     expect(
@@ -199,6 +246,20 @@ test("Test parsing of multi line reversed cards", () => {
         [CardType.MultiLineBasic, "Question 1\n?\nAnswer line 1\nAnswer line 2", 0, 4],
         [CardType.MultiLineReversed, "Question 2\n??\nAnswer line 1\nAnswer line 2", 6, 9],
     ]);
+
+    // custom symbols
+    expect(
+        parse("Question\n@@@\nAnswer\n---", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "@@",
+            multilineReversedCardSeparator: "@@@",
+            multilineCardEndMarker: "---",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([[CardType.MultiLineReversed, "Question\n@@@\nAnswer", 0, 2]]);
 });
 
 test("Test parsing of cloze cards", () => {
@@ -228,6 +289,7 @@ test("Test parsing of cloze cards", () => {
     expect(parse("srdf ==", parserOptions)).toEqual([]);
     expect(parse("lorem ipsum ==p\ndolor won==", parserOptions)).toEqual([]);
     expect(parse("lorem ipsum ==dolor won=", parserOptions)).toEqual([]);
+
     // ==highlights== turned off
     expect(
         parse("cloze ==deletion== test", {
@@ -238,7 +300,7 @@ test("Test parsing of cloze cards", () => {
             multilineCardEndMarker: "",
             convertHighlightsToClozes: false,
             convertBoldTextToClozes: true,
-            convertCurlyBracketsToClozes: false,
+            convertCurlyBracketsToClozes: true,
         }),
     ).toEqual([]);
 
@@ -268,6 +330,7 @@ test("Test parsing of cloze cards", () => {
     expect(parse("srdf **", parserOptions)).toEqual([]);
     expect(parse("lorem ipsum **p\ndolor won**", parserOptions)).toEqual([]);
     expect(parse("lorem ipsum **dolor won*", parserOptions)).toEqual([]);
+
     // **bolded** turned off
     expect(
         parse("cloze **deletion** test", {
@@ -278,15 +341,56 @@ test("Test parsing of cloze cards", () => {
             multilineCardEndMarker: "",
             convertHighlightsToClozes: true,
             convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: true,
+        }),
+    ).toEqual([]);
+
+    // {{curly}}
+    expect(parse("cloze {{deletion}} test", parserOptions)).toEqual([
+        [CardType.Cloze, "cloze {{deletion}} test", 0, 0],
+    ]);
+    expect(parse("cloze {{deletion}} test\n<!--SR:2021-08-11,4,270-->", parserOptions)).toEqual([
+        [CardType.Cloze, "cloze {{deletion}} test\n<!--SR:2021-08-11,4,270-->", 0, 1],
+    ]);
+    expect(parse("cloze {{deletion}} test <!--SR:2021-08-11,4,270-->", parserOptions)).toEqual([
+        [CardType.Cloze, "cloze {{deletion}} test <!--SR:2021-08-11,4,270-->", 0, 0],
+    ]);
+    expect(parse("{{this}} is a {{deletion}}\n", parserOptions)).toEqual([
+        [CardType.Cloze, "{{this}} is a {{deletion}}", 0, 0],
+    ]);
+    expect(
+        parse(
+            "some text before\n\na deletion on\nsuch {{wow}}\n\n" +
+                "many text\nsuch surprise {{wow}} more {{text}}\nsome text after\n\nHmm",
+            parserOptions,
+        ),
+    ).toEqual([
+        [CardType.Cloze, "a deletion on\nsuch {{wow}}", 2, 3],
+        [CardType.Cloze, "many text\nsuch surprise {{wow}} more {{text}}\nsome text after", 5, 7],
+    ]);
+    expect(parse("srdf {{", parserOptions)).toEqual([]);
+    expect(parse("srdf }}", parserOptions)).toEqual([]);
+    expect(parse("lorem ipsum {{p\ndolor won}}", parserOptions)).toEqual([]);
+    expect(parse("lorem ipsum {{dolor won}", parserOptions)).toEqual([]);
+
+    // {{curly}} turned off
+    expect(
+        parse("cloze {{deletion}} test", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "",
+            convertHighlightsToClozes: true,
+            convertBoldTextToClozes: true,
             convertCurlyBracketsToClozes: false,
         }),
     ).toEqual([]);
 
-    // both
+    // combo
     expect(parse("cloze **deletion** test ==another deletion==!", parserOptions)).toEqual([
         [CardType.Cloze, "cloze **deletion** test ==another deletion==!", 0, 0],
     ]);
-
     expect(
         parse(
             "Test 1\nTest 2\nThis is a close with ===secret=== text.\nWith this extra lines\n\nAnd more here.\nAnd even more.\n\n---\n\nTest 3\nTest 4\nThis is a close with ===super secret=== text.\nWith this extra lines\n\nAnd more here.\nAnd even more.\n\n---\n\nHere is some more text.",
@@ -315,6 +419,20 @@ test("Test parsing of cloze cards", () => {
             17,
         ],
     ]);
+
+    // all disabled
+    expect(
+        parse("cloze {{deletion}} test and **deletion** ==another deletion==!", {
+            singleLineCardSeparator: "::",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "",
+            convertHighlightsToClozes: false,
+            convertBoldTextToClozes: false,
+            convertCurlyBracketsToClozes: false,
+        }),
+    ).toEqual([]);
 });
 
 test("Test parsing of a mix of card types", () => {
@@ -340,12 +458,12 @@ test("Test parsing of a mix of card types", () => {
             CardType.MultiLineReversed,
             "Donec dapibus ullamcorper aliquam.\n??\nDonec dapibus ullamcorper aliquam.\n<!--SR:2021-08-11,4,270-->",
             8,
-            11 /* <!--SR:2021-08-11,4,270--> */,
+            11,
         ],
     ]);
 });
 
-test("Test codeblocks", () => {
+test("Test parsing cards with codeblocks", () => {
     // no blank lines
     expect(
         parse(
@@ -359,7 +477,7 @@ test("Test codeblocks", () => {
             "How do you ... Python?\n?\n" +
                 "```\nprint('Hello World!')\nprint('Howdy?')\nlambda x: x[0]\n```",
             0,
-            6 /* ``` */,
+            6,
         ],
     ]);
 
@@ -376,7 +494,7 @@ test("Test codeblocks", () => {
             "How do you ... Python?\n?\n" +
                 "```\nprint('Hello World!')\n\n\nprint('Howdy?')\n\nlambda x: x[0]\n```",
             0,
-            9 /* ``` */,
+            9,
         ],
     ]);
 
@@ -409,12 +527,14 @@ test("Test codeblocks", () => {
                 "~~~\n" +
                 "````",
             0,
-            12 /* ``` */,
+            12,
         ],
     ]);
 });
 
 test("Test not parsing cards in HTML comments", () => {
+    expect(parse("<!--question::answer test-->", parserOptions)).toEqual([]);
+    expect(parse("<!--question:::answer test-->", parserOptions)).toEqual([]);
     expect(
         parse("<!--\nQuestion\n?\nAnswer <!--SR:!2021-08-11,4,270-->\n-->", parserOptions),
     ).toEqual([]);
@@ -426,6 +546,46 @@ test("Test not parsing cards in HTML comments", () => {
     ).toEqual([]);
     expect(parse("<!--cloze ==deletion== test-->", parserOptions)).toEqual([]);
     expect(parse("<!--cloze **deletion** test-->", parserOptions)).toEqual([]);
+    expect(parse("<!--cloze {{curly}} test-->", parserOptions)).toEqual([]);
+});
+
+test("Test not parsing 'cards' in codeblocks", () => {
+    // block
+    expect(parse("```\nCodeblockq::CodeblockA\n```", parserOptions)).toEqual([]);
+    expect(parse("```\nCodeblockq:::CodeblockA\n```", parserOptions)).toEqual([]);
+    expect(
+        parse("# Title\n\n```markdown\nsome ==highlighted text==!\n```\n\nmore!", parserOptions),
+    ).toEqual([]);
+    expect(
+        parse("# Title\n```markdown\nsome **bolded text**!\n```\n\nmore!", parserOptions),
+    ).toEqual([]);
+    expect(parse("# Title\n\n```\nfoo = {{'a': 2}}\n```\n\nmore!", parserOptions)).toEqual([]);
+
+    // inline
+    expect(parse("`Inlineq::InlineA`", parserOptions)).toEqual([]);
+    expect(
+        parse("# Title\n`if (a & b) {}`\nmore!", {
+            singleLineCardSeparator: "&",
+            singleLineReversedCardSeparator: ":::",
+            multilineCardSeparator: "?",
+            multilineReversedCardSeparator: "??",
+            multilineCardEndMarker: "",
+            convertHighlightsToClozes: true,
+            convertBoldTextToClozes: true,
+            convertCurlyBracketsToClozes: true,
+        }),
+    ).toEqual([]);
+    expect(parse("# Title\n`if a == b && c == d {}`\nmore!", parserOptions)).toEqual([]);
+    expect(parse("# Title\n\n`z = a ** b + 5 ** 7`\n\nmore!", parserOptions)).toEqual([]);
+    expect(parse("# Title\n`foo = {{'a': 2}}`\n\nmore!", parserOptions)).toEqual([]);
+
+    // combo
+    expect(
+        parse(
+            "Question::Answer\n\n```\nCodeblockq::CodeblockA\n```\n\n`Inlineq::InlineA`\n",
+            parserOptions,
+        ),
+    ).toEqual([[CardType.SingleLineBasic, "Question::Answer", 0, 0]]);
 });
 
 test("Unexpected Error case", () => {


### PR DESCRIPTION
This PR:

1. Renames _close_ in the grammar to _cloze_
2. Adds test cases for parsing {{curly}} clozes
3. Fixes #1072
    - Ignores 'cards' in ```block`` & `inline` codeblocks
    - Adds test cases for both
4. Fixes #1077 
    - When all the cloze options aren't being used, `cloze_rules` in `parser.ts` becomes empty which leads to the empty grammar rule `cloze_text` which prevents the parser from being generated. This change puts a [tombstone](https://en.wikipedia.org/wiki/Tombstone_(data_store)) `\0` instead to address this.
    - Adds test cases for this