### PR TITLE
fix: ignore with glob patterns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint and Test
+name: Lint and Test Code
 
 on:
     pull_request:
@@ -8,7 +8,7 @@ env:
     COREPACK_ENABLE_STRICT: 0
 
 jobs:
-    lint_and_test:
+    lint_and_test_code:
         runs-on: ubuntu-latest
 
         steps:

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     },
     "dependencies": {
         "chart.js": "^4.4.4",
+        "minimatch": "^10.0.1",
         "pagerank.js": "^1.0.2",
         "peggy": "^4.0.3"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   chart.js:
     specifier: ^4.4.4
     version: 4.4.4
+  minimatch:
+    specifier: ^10.0.1
+    version: 10.0.1
   pagerank.js:
     specifier: ^1.0.2
     version: 1.0.2
@@ -1501,7 +1504,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1514,7 +1516,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3174,6 +3175,13 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
     dev: true
+
+  /minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}

--- a/src/gui/flashcard-review-view.tsx
+++ b/src/gui/flashcard-review-view.tsx
@@ -360,7 +360,7 @@ export class FlashcardReviewView {
             }
             result += separator + context;
         });
-        return result + separator + "...";
+        return result;
     }
 
     // -> Header

--- a/src/lang/locale/ar.ts
+++ b/src/lang/locale/ar.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "مجلدات لتجاهلها",
-    FOLDERS_TO_IGNORE_DESC: `Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes. : أدخل مسارات المجلد مفصولة بواسطة سطور جديدة,مثال`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "البطاقات",
     FLASHCARD_EASY_LABEL: "نص الزر سهل",

--- a/src/lang/locale/cz.ts
+++ b/src/lang/locale/cz.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Ignorované složky",
-    FOLDERS_TO_IGNORE_DESC: `Zadejte cesty ke složkám oddělené odřádkováním napříkad. Šablony Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Kartičky",
     FLASHCARD_EASY_LABEL: "Easy Button Text",

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -77,8 +77,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Ausgeschlossene Ordner",
-    FOLDERS_TO_IGNORE_DESC: `Mehrere Ordner mit Zeilenumbrüchen getrennt angeben. Bsp. OrdnerA[Zeilenumbruch]OrdnerB/Unterordner.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Lernkarten",
     FLASHCARD_EASY_LABEL: "Einfach Knopf Text",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Folders to ignore",
-    FOLDERS_TO_IGNORE_DESC: `Enter folder paths separated by newlines e.g. Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Flashcards",
     FLASHCARD_EASY_LABEL: "Easy Button Text",

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Directorios a ignorar",
-    FOLDERS_TO_IGNORE_DESC: `Escriba las rutas de los directorios separadas por saltos de línea, por ejemplo, Plantillas Extra/Guiones.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Tarjetas de Memorización",
     FLASHCARD_EASY_LABEL: "Texto del botón: Fácil",

--- a/src/lang/locale/fr.ts
+++ b/src/lang/locale/fr.ts
@@ -72,8 +72,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Créez un ticket <a href="${issues_url}">sur GitHub</a> si vous trouvez un bug ou voulez demander une fonctionnalité',
     FOLDERS_TO_IGNORE: "Dossiers à ignorer",
-    FOLDERS_TO_IGNORE_DESC: `Entrez les chemins des dossiers. Un chemin par ligne, ex. Templates Meta/Scripts.
-Ce réglage est le même pour les flashcards et les notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Flashcards",
     FLASHCARD_EASY_LABEL: "Bouton Facile",

--- a/src/lang/locale/it.ts
+++ b/src/lang/locale/it.ts
@@ -72,8 +72,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Cartelle da ignorare",
-    FOLDERS_TO_IGNORE_DESC: `Inserisci i percorsi delle cartelle separati da a capo, per esempio, Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Schede",
     FLASHCARD_EASY_LABEL: "Testo del bottone facile",

--- a/src/lang/locale/ja.ts
+++ b/src/lang/locale/ja.ts
@@ -72,8 +72,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "無視するフォルダ",
-    FOLDERS_TO_IGNORE_DESC: `フォルダパスを改行で区切って入力してください。"Templates Meta/Scripts" のようなスペースによる区切りでの書き方は無効です。.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "フラッシュカード",
     FLASHCARD_EASY_LABEL: "Easy Button Text",

--- a/src/lang/locale/ko.ts
+++ b/src/lang/locale/ko.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "무시할 폴더들",
-    FOLDERS_TO_IGNORE_DESC: `폴더 경로를 빈 줄로 구분해서 입력해주세요. 'Templates Meta/Scripts' 와 같이 입력하는 것은 유효하지 않습니다.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "플래시카드",
     FLASHCARD_EASY_LABEL: "Easy Button Text",

--- a/src/lang/locale/pl.ts
+++ b/src/lang/locale/pl.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Foldery do zignorowania",
-    FOLDERS_TO_IGNORE_DESC: `Wprowadź ścieżki folderów oddzielone nowymi liniami, np. Szablony Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Fiszki",
     FLASHCARD_EASY_LABEL: "Tekst przycisku Łatwe",

--- a/src/lang/locale/pt-br.ts
+++ b/src/lang/locale/pt-br.ts
@@ -73,8 +73,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Pastas para ignorar",
-    FOLDERS_TO_IGNORE_DESC: `Insira o caminho das pastas separado por quebras de linha ex: Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Flashcards",
     FLASHCARD_EASY_LABEL: "Texto do Botão de Fácil",

--- a/src/lang/locale/ru.ts
+++ b/src/lang/locale/ru.ts
@@ -80,8 +80,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "Игнорируемые папки",
-    FOLDERS_TO_IGNORE_DESC: `Укажите пути папок, каждый на своей строке, например: Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Карточки",
     FLASHCARD_EASY_LABEL: 'Текст кнопки "Легко"',

--- a/src/lang/locale/tr.ts
+++ b/src/lang/locale/tr.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Bir özellik isteğiniz ya da hata bildiriminiz varsa <a href="${issues_url}">buradan</a> bildirin.',
     FOLDERS_TO_IGNORE: "Yoksayılan Klasörler",
-    FOLDERS_TO_IGNORE_DESC: `Klasör yollarını yeni satırlarla ayırarak girin, örneğin: Templates Meta/Scripts.
-    Bu ayarın hem Flash Kartlar hem de Notlar için geçerli olduğunu unutmayın.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "Flash Kartlar",
     FLASHCARD_EASY_LABEL: "Kolay Butonu Metni",

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "忽略此文件夹",
-    FOLDERS_TO_IGNORE_DESC: `输入文件夹路径，用新建行分隔，例如：Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "卡片",
     FLASHCARD_EASY_LABEL: "“简单”按钮文本",

--- a/src/lang/locale/zh-tw.ts
+++ b/src/lang/locale/zh-tw.ts
@@ -71,8 +71,8 @@ export default {
     PROJECT_CONTRIBUTIONS:
         'Raise an issue <a href="${issues_url}">here</a> if you have a feature request or a bug-report',
     FOLDERS_TO_IGNORE: "忽略此資料夾",
-    FOLDERS_TO_IGNORE_DESC: `輸入資料夾路徑（用換行字元分隔），例如：Templates Meta/Scripts.
-Note that this setting is common to both Flashcards and Notes.`,
+    FOLDERS_TO_IGNORE_DESC:
+        "Enter folder paths or glob patterns on separate lines e.g. Templates Meta/Scripts or **/*.excalidraw.md. This setting is common to both flashcards and notes.",
     OBSIDIAN_INTEGRATION: "Integration into Obsidian",
     FLASHCARDS: "卡片",
     FLASHCARD_EASY_LABEL: "簡單按鈕文字",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import { createTabs, TabStructure } from "src/gui/tabs";
 import { t } from "src/lang/helpers";
 import type SRPlugin from "src/main";
 import { setDebugParser } from "src/parser";
+import { pathMatchesPattern } from "src/utils/utils";
 
 export interface SRSettings {
     // flashcards
@@ -123,7 +124,7 @@ export class SettingsUtil {
     }
 
     static isPathInNoteIgnoreFolder(settings: SRSettings, path: string): boolean {
-        return settings.noteFoldersToIgnore.some((folder) => path.startsWith(folder));
+        return settings.noteFoldersToIgnore.some((folder) => pathMatchesPattern(path, folder));
     }
 
     static isAnyTagANoteReviewTag(settings: SRSettings, tags: string[]): boolean {
@@ -619,7 +620,8 @@ export class SRSettingTab extends PluginSettingTab {
                         applySettingsUpdate(async () => {
                             this.plugin.data.settings.noteFoldersToIgnore = value
                                 .split(/\n+/)
-                                .map((v) => v.trim());
+                                .map((v) => v.trim())
+                                .filter((v) => v);
                             await this.plugin.savePluginData();
                         });
                     }),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import { minimatch } from "minimatch";
 import moment, { Moment } from "moment";
 import { sep } from "path";
 
@@ -387,4 +388,12 @@ export function parseObsidianFrontmatterTag(tagStr: string): string[] {
         }
     }
     return result;
+}
+
+// This checks if the given path matches the given pattern
+// We match based on:
+//  1. The `path` starts with `pattern`
+//  2. The `path` matches the glob `pattern`
+export function pathMatchesPattern(path: string, pattern: string) {
+    return path.startsWith(pattern) || minimatch(path, pattern);
 }

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -9,6 +9,7 @@ import {
     getTypedObjectEntries,
     isEqualOrSubPath,
     literalStringReplace,
+    pathMatchesPattern,
     splitNoteIntoFrontmatterAndContent,
     splitTextIntoLineArray,
     stringTrimStart,
@@ -296,39 +297,48 @@ describe("stringTrimStart", () => {
         expect(stringTrimStart("")).toEqual(["", ""]);
         expect(stringTrimStart(undefined)).toEqual(["", ""]);
     });
+
     test("No white spaces", () => {
         expect(stringTrimStart("any text here")).toEqual(["", "any text here"]);
     });
+
     test("Only white spaces", () => {
         expect(stringTrimStart(" ")).toEqual([" ", ""]);
         expect(stringTrimStart("   ")).toEqual(["   ", ""]);
     });
+
     test("Leading white spaces", () => {
         expect(stringTrimStart(" any text here")).toEqual([" ", "any text here"]);
         expect(stringTrimStart("  any text here")).toEqual(["  ", "any text here"]);
     });
+
     test("Trailing white spaces", () => {
         expect(stringTrimStart("any text here ")).toEqual(["", "any text here "]);
         expect(stringTrimStart("any text here  ")).toEqual(["", "any text here  "]);
     });
+
     test("Leading tabs", () => {
         expect(stringTrimStart("\tany text here")).toEqual(["\t", "any text here"]);
         expect(stringTrimStart("\t\tany text here")).toEqual(["\t\t", "any text here"]);
     });
+
     test("Trailing tabs", () => {
         expect(stringTrimStart("any text here\t")).toEqual(["", "any text here\t"]);
         expect(stringTrimStart("any text here\t\t")).toEqual(["", "any text here\t\t"]);
     });
+
     test("Mixed leading whitespace (spaces and tabs)", () => {
         expect(stringTrimStart(" \tany text here")).toEqual([" \t", "any text here"]);
         expect(stringTrimStart("\t any text here")).toEqual(["\t ", "any text here"]);
         expect(stringTrimStart(" \t any text here")).toEqual([" \t ", "any text here"]);
     });
+
     test("Mixed trailing whitespace (spaces and tabs)", () => {
         expect(stringTrimStart("any text here \t")).toEqual(["", "any text here \t"]);
         expect(stringTrimStart("any text here\t ")).toEqual(["", "any text here\t "]);
         expect(stringTrimStart("any text here \t ")).toEqual(["", "any text here \t "]);
     });
+
     test("Newlines and leading spaces", () => {
         expect(stringTrimStart("\nany text here")).toEqual(["\n", "any text here"]);
         expect(stringTrimStart("\n any text here")).toEqual(["\n ", "any text here"]);
@@ -738,6 +748,7 @@ describe("isEqualOrSubPath", () => {
             expect(isEqualOrSubPath(root + winSep + linSep + sub_1, root)).toBe(true);
         });
     });
+
     describe("Linux", () => {
         const sep = linSep;
         const rootPath = root + sep + sub_1;
@@ -755,7 +766,7 @@ describe("isEqualOrSubPath", () => {
             expect(isEqualOrSubPath(root + linSep + sub_1 + linSep, rootPath)).toBe(true);
         });
 
-        test("Differnent path", () => {
+        test("Different path", () => {
             expect(isEqualOrSubPath(noMatch, rootPath)).toBe(false);
             expect(isEqualOrSubPath(noMatch + sep, rootPath)).toBe(false);
             expect(isEqualOrSubPath(noMatch + sep + sub_1, rootPath)).toBe(false);
@@ -795,11 +806,47 @@ describe("isEqualOrSubPath", () => {
             expect(isEqualOrSubPath(root + winSep + linSep + sub_1, root)).toBe(true);
         });
     });
+
     test("Examples", () => {
         expect(isEqualOrSubPath("/user/docs/letter.txt", "/user/docs")).toBe(true);
         expect(isEqualOrSubPath("/user/docs", "/user/docs")).toBe(true);
         expect(isEqualOrSubPath("/user/docs/letter.txt", "/user/projects")).toBe(false);
         expect(isEqualOrSubPath("/User/Docs", "/user/docs")).toBe(true);
         expect(isEqualOrSubPath("C:\\user\\docs", "C:/user/docs")).toBe(true);
+    });
+});
+
+describe("pathMatchesPattern", () => {
+    test("Paths that match", () => {
+        expect(pathMatchesPattern("Computing/AWS/DynamoDB/Streams.md", "Computing/AWS")).toBe(true);
+        expect(pathMatchesPattern("Computing/AWS/DynamoDB/Streams.md", "Computing/AWS/")).toBe(
+            true,
+        );
+        expect(
+            pathMatchesPattern("Computing/GCP/DynamoDB/Streams.md", "Computing/*/DynamoDB/*"),
+        ).toBe(true);
+        expect(pathMatchesPattern("Computing/AWS/DynamoDB/Streams.md", "Computing/**")).toBe(true);
+        expect(
+            pathMatchesPattern("Computing/AWS/DynamoDB/Streams.md", "Computing/AWS/DynamoDB/*"),
+        ).toBe(true);
+
+        expect(pathMatchesPattern("Computing/AWS/foo.excalidraw.md", "**/*.excalidraw.md")).toBe(
+            true,
+        );
+        expect(
+            pathMatchesPattern(
+                "Computing/Drawing 2024-09-22 15.12.39.excalidraw.md",
+                "*/*.excalidraw.md",
+            ),
+        ).toBe(true);
+    });
+
+    test("Paths that don't match", () => {
+        expect(pathMatchesPattern("Math/Singular Matrix.md", "Computing/AWS")).toBe(false);
+        expect(pathMatchesPattern("AWS/DynamoDB/Streams.md", "Computing/*/DynamoDB/")).toBe(false);
+
+        expect(pathMatchesPattern("Computing/AWS/DynamoDB/Streams.md", "**/*.excalidraw.md")).toBe(
+            false,
+        );
     });
 });


### PR DESCRIPTION
This allows the user to ignore folders using glob patterns. For instance:

- `Computing/AWS/DynamoDB/*`
- `**/*.excalidraw.md`
- `Computing/**`
- `Computing/*/DynamoDB/*`

This was originally reported in https://github.com/open-spaced-repetition/obsidian-spaced-repetition-recall/issues/72 where the plugin was interpreting things inside excalidraw files as ==highlight== cloze cards. Like `==⚠  Switch to EXCALIDRAW VIEW in the MORE OPTIONS menu of this document. ⚠== You can decompress Drawing data with the command palette: 'Decompress current Excalidraw file'. For more info check in plugin settings under 'Saving'`.