### PR TITLE
fix: Review only due notes

### DIFF
--- a/src/note-review-deck.ts
+++ b/src/note-review-deck.ts
@@ -1,5 +1,6 @@
 import { t } from "src/lang/helpers";
 import { ISRFile } from "src/sr-file";
+import { globalDateProvider } from "src/utils/dates";
 import { globalRandomNumberProvider } from "src/utils/numbers";
 
 export class SchedNote {
@@ -81,10 +82,12 @@ export class NoteReviewDeck {
     determineNextNote(openRandomNote: boolean): ISRFile {
         // Review due notes before new ones
         if (this.dueNotesCount > 0) {
+            const todayUnix: number = globalDateProvider.today.valueOf();
+            const dueNotes = this.scheduledNotes.filter((note) => note.isDue(todayUnix));
             const index = openRandomNote
-                ? globalRandomNumberProvider.getInteger(0, this.dueNotesCount - 1)
+                ? globalRandomNumberProvider.getInteger(0, dueNotes.length - 1)
                 : 0;
-            return this.scheduledNotes[index].note;
+            return dueNotes[index].note;
         }
 
         if (this.newNotes.length > 0) {


### PR DESCRIPTION
This patch fixes the behaviour of determining the next note to only consider notes that are due. If a note is scheduled in the future, it won't be picked up for review until it's due.

This is the same patch as #947.

Fixes #328.