### PR TITLE
fix: Only consider filtered notes for next note

### DIFF
--- a/src/note-review-deck.ts
+++ b/src/note-review-deck.ts
@@ -81,9 +81,9 @@ export class NoteReviewDeck {
 
     determineNextNote(openRandomNote: boolean): ISRFile {
         // Review due notes before new ones
-        if (this.dueNotesCount > 0) {
-            const todayUnix: number = globalDateProvider.today.valueOf();
-            const dueNotes = this.scheduledNotes.filter((note) => note.isDue(todayUnix));
+        const todayUnix: number = globalDateProvider.today.valueOf();
+        const dueNotes = this.scheduledNotes.filter((note) => note.isDue(todayUnix));
+        if (dueNotes.length > 0) {
             const index = openRandomNote
                 ? globalRandomNumberProvider.getInteger(0, dueNotes.length - 1)
                 : 0;


### PR DESCRIPTION
The previous patch #1088 missed to change the conditional to also include only the filtered notes. With this patch, if all scheduled notes are in the future, it will choose a new note for review.