### PR TITLE
fix(multiline cards): the Qn should start from the immediate empty line above it

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -120,7 +120,7 @@ export function parse(text: string, options: ParserOptions): ParsedQuestionInfo[
             // We've probably reached the end of a card
             (isEmptyLine && !options.multilineCardEndMarker) ||
             // Empty line & we're not picking up any card
-            (isEmptyLine && cardText.length == 0) ||
+            (isEmptyLine && cardType == null) ||
             // We've reached the end of a multi line card &
             //  we're using custom end markers
             hasMultilineCardEndMarker

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -298,6 +298,40 @@ test("Test parsing of multi line reversed cards", () => {
             clozePatterns: [],
         }),
     ).toEqual([[CardType.MultiLineReversed, "Question\n@@@\nAnswer", 0, 2]]);
+    expect(
+        parseT(
+            `line 1
+
+
+line 2
+
+Question 1?
+??
+Answer to question 1
+????
+line 3
+
+line 4
+
+Question 2?
+??
+Answer to question 2
+????
+Line 5
+`,
+            {
+                singleLineCardSeparator: ":::",
+                singleLineReversedCardSeparator: "::::",
+                multilineCardSeparator: "??",
+                multilineReversedCardSeparator: "???",
+                multilineCardEndMarker: "????",
+                clozePatterns: [],
+            },
+        ),
+    ).toEqual([
+        [CardType.MultiLineBasic, "Question 1?\n??\nAnswer to question 1", 5, 7],
+        [CardType.MultiLineBasic, "Question 2?\n??\nAnswer to question 2", 13, 15],
+    ]);
 
     // empty string or whitespace character provided
     expect(


### PR DESCRIPTION
Fix issue reported in  https://github.com/st3v3nmw/obsidian-spaced-repetition/issues/1136.

![image](https://github.com/user-attachments/assets/978450e1-3f08-44b0-bf89-2c96140f170e)

![image](https://github.com/user-attachments/assets/4efe6545-46f7-4845-ab95-a1cb890e7f7d)
