### PR TITLE
fix: modal CSS to make modal full screen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,10 +31,15 @@
 }
 
 #sr-modal {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100vh !important;
+    max-height: 100vh !important;
+    margin: 0 !important;
+    position: fixed !important;
+    left: 50% !important;
+    top: 50% !important;
+    transform: translate(-50%, -50%) !important;
 }
 
 #sr-modal .modal-title {


### PR DESCRIPTION
The plugin is unusable on mobile #1171
This is beacuse the modal renders too narrow to be usable on mobile. Fixing this by making the modal fullscreen, across all platforms.

Here's the before and after on desktop:
|Before|After|
|-|-|
|![Pasted image 20241125095107](https://github.com/user-attachments/assets/b094c517-6e15-4e1f-9e3b-272ec3339e03)|![Pasted image 20241125095229](https://github.com/user-attachments/assets/1a52aa42-e107-486d-9b15-89d9577ac7d0)|

