### PR TITLE
fix(scheduler): clear buried questions on new day

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,7 @@ export default class SRPlugin extends Plugin {
             this.data.settings,
             this.data.buryList,
         );
+        await questionPostponementList.clearIfNewDay(this.data)
 
         const osrNoteLinkInfoFinder: ObsidianVaultNoteLinkInfoFinder =
             new ObsidianVaultNoteLinkInfoFinder(this.app.metadataCache);

--- a/src/question-postponement-list.ts
+++ b/src/question-postponement-list.ts
@@ -22,8 +22,7 @@ export class QuestionPostponementList implements IQuestionPostponementList {
     }
 
     async clearIfNewDay(data: PluginData): Promise<void> {
-        const now = window.moment(Date.now());
-        const todayDate: string = now.format("YYYY-MM-DD");
+        const todayDate = this._todayDate()
 
         // clear bury list if we've changed dates
         const isNewDay: boolean = todayDate !== data.buryDate;
@@ -50,6 +49,17 @@ export class QuestionPostponementList implements IQuestionPostponementList {
         // This is null only whilst unit testing is being performed
         if (this.plugin == null) return;
 
+        // set buryDate before writing so we can clear bury list on new day
+        const todayDate = this._todayDate()
+        this.plugin.data.buryDate = todayDate
+
         await this.plugin.savePluginData();
     }
+
+    _todayDate(): string {
+        const now = window.moment(Date.now());
+        const todayDate: string = now.format("YYYY-MM-DD");
+        return todayDate
+    }
+
 }


### PR DESCRIPTION
the logic here seemed to be half-there but maybe missed in a refactor?
the method clearIfNewDay was already implemented but not used anywhere in the codebase. the method is now called and
questionPostponementList.write now sets `buryDate` to the current date when called.