### PR TITLE
fix: Change Decks list card count box size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -233,7 +233,7 @@ body:not(.native-scrollbars) #sr-modal .modal-close-button {
 }
 
 .sr-deck-list .sr-tree-stats-count {
-    min-width: 3ch;
+    min-width: 4ch;
     padding: 4px;
     box-sizing: content-box;
     text-align: center;


### PR DESCRIPTION
Changed the minimum width of the boxes, that there will fit for numbers up to 9999. Currently there only will fit if the numbers are below 999 what in my case and certainly for others too is not enough.

Old:
![image](https://github.com/user-attachments/assets/948499f5-9271-4e57-a8e9-77d8693e517c)

New: 
![image](https://github.com/user-attachments/assets/8aebb510-fdbc-427f-b68c-01f51a553256)
