### PR TITLE
feat: Apply "Option for viewing sr decks and cards in tabs" feature to Ribbon callback

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -538,11 +538,18 @@ export default class SRPlugin extends Plugin {
             this.ribbonIcon = this.addRibbonIcon("SpacedRepIcon", t("REVIEW_CARDS"), async () => {
                 if (!this.osrAppCore.syncLock) {
                     await this.sync();
-                    this.openFlashcardModal(
-                        this.osrAppCore.reviewableDeckTree,
-                        this.osrAppCore.remainingDeckTree,
-                        FlashcardReviewMode.Review,
-                    );
+                    if (this.data.settings.openViewInNewTab) {
+                        this.tabViewManager.openSRTabView(
+                            this.osrAppCore,
+                            FlashcardReviewMode.Review,
+                        );
+                    } else {
+                        this.openFlashcardModal(
+                            this.osrAppCore.reviewableDeckTree,
+                            this.osrAppCore.remainingDeckTree,
+                            FlashcardReviewMode.Review,
+                        );
+                    }
                 }
             });
         }


### PR DESCRIPTION
I wanted to try the feature in #1169, so I built it from the latest version and found that it didn’t work. Later, I discovered that it worked when  opened via command, but it didn’t work when opened via Ribbon. I guessed that the Ribbon callback might have been forgotten to be modified. So, I referred to the command callback implementation and modified the Ribbon callback part accordingly.