### PR TITLE
Add check to make sure card context exists

### DIFF
--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -440,6 +440,7 @@ export class CardUI {
     }
 
     private _updateCardContext() {
+        if (!this.cardContext) return;
         if (!this.settings.showContextInCards) {
             this.cardContext.setText("");
             return;


### PR DESCRIPTION
Checks that the `cardContext` exists before trying to set it. Resolves the issue where disabling the **Show context in cards** setting would cause the flashcard not to load. 

Closes #1250 and #1253