### PR TITLE
fix: prevent error when showContextInCards is disabled by checking cardContext existence

### DIFF
--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -440,6 +440,7 @@ export class CardUI {
     }
 
     private _updateCardContext() {
+        if (!this.cardContext) return;
         if (!this.settings.showContextInCards) {
             this.cardContext.setText("");
             return;

--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -489,7 +489,7 @@ export class CardUI {
         this.answerButton.addClasses(["sr-response-button", "sr-show-answer-button", "sr-bg-blue"]);
         this.answerButton.setText(t("SHOW_ANSWER"));
         this.answerButton.addEventListener("click", () => {
-            this.nswer();
+            this._showAnswer();
         });
     }
 

--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -489,7 +489,7 @@ export class CardUI {
         this.answerButton.addClasses(["sr-response-button", "sr-show-answer-button", "sr-bg-blue"]);
         this.answerButton.setText(t("SHOW_ANSWER"));
         this.answerButton.addEventListener("click", () => {
-            this._showAnswer();
+            this.nswer();
         });
     }
 
@@ -615,6 +615,13 @@ export class CardUI {
                 this.easyButton,
                 this.settings.flashcardEasyText,
                 ReviewResponse.Easy,
+            );
+        }
+        if (!this.settings.showContextInCards) {
+            this.cardContext = this.infoSection.createDiv();
+            this.cardContext.addClass("sr-context");
+            this.cardContext.setText(
+                ` ${this._formatQuestionContextText(this._currentQuestion.questionContext)}`,
             );
         }
     }


### PR DESCRIPTION
If I turn off the "show context in cards" option, there will be nothing left on the cards, not even the question.