### PR TITLE
Add defensive checks in _updateCardContext to avoid undefined cardCon…

### DIFF
--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -441,13 +441,17 @@ export class CardUI {
 
     private _updateCardContext() {
         if (!this.settings.showContextInCards) {
-            this.cardContext.setText("");
+          if (this.cardContext) {
+                this.cardContext.setText("");
+            }
             return;
         }
-        this.cardContext.setText(
-            ` ${this._formatQuestionContextText(this._currentQuestion.questionContext)}`,
-        );
-    }
+       if (this.cardContext) {
+            this.cardContext.setText(
+                ` 
+${this._formatQuestionContextText(this._currentQuestion.questionContext)}`,
+            );
+        }
 
     private _formatQuestionContextText(questionContext: string[]): string {
         const separator: string = " > ";


### PR DESCRIPTION
Fixes issue #1263 by adding defensive checks in `_updateCardContext`. The method now checks if `this.cardContext` exists before calling `setText()` to prevent undefined errors when `showContextInCards` is disabled.