### PR TITLE
feat: Adds a button to jump to the current item in your notes

### DIFF
--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -59,6 +59,7 @@ export class CardUI {
 
     public controls: HTMLDivElement;
     public editButton: HTMLButtonElement;
+    public jumpToButton: HTMLButtonElement;
     public resetButton: HTMLButtonElement;
     public infoButton: HTMLButtonElement;
     public skipButton: HTMLButtonElement;
@@ -83,6 +84,7 @@ export class CardUI {
     private reviewMode: FlashcardReviewMode;
     private backToDeck: () => void;
     private editClickHandler: () => void;
+    private jumpToClickHandler: () => Promise<void>;
 
     constructor(
         app: App,
@@ -93,6 +95,7 @@ export class CardUI {
         view: HTMLDivElement,
         backToDeck: () => void,
         editClickHandler: () => void,
+        jumpToClickHandler: () => Promise<void>,
     ) {
         // Init properties
         this.app = app;
@@ -102,6 +105,7 @@ export class CardUI {
         this.reviewMode = reviewMode;
         this.backToDeck = backToDeck;
         this.editClickHandler = editClickHandler;
+        this.jumpToClickHandler = jumpToClickHandler;
         this.view = view;
         this.chosenDeck = null;
 
@@ -254,6 +258,7 @@ export class CardUI {
 
     private _createCardControls() {
         this._createEditButton();
+        this._createJumpToButton();
         this._createResetButton();
         this._createCardInfoButton();
         this._createSkipButton();
@@ -266,6 +271,16 @@ export class CardUI {
         this.editButton.setAttribute("aria-label", t("EDIT_CARD"));
         this.editButton.addEventListener("click", async () => {
             this.editClickHandler();
+        });
+    }
+
+    private _createJumpToButton() {
+        this.jumpToButton = this.controls.createEl("button");
+        this.jumpToButton.addClasses(["sr-button", "sr-jumpto-button"]);
+        setIcon(this.jumpToButton, "arrow-up-right");
+        this.jumpToButton.setAttribute("aria-label", t("OPEN_NOTE_FOR_REVIEW"));
+        this.jumpToButton.addEventListener("click", async () => {
+            await this.jumpToClickHandler();
         });
     }
 

--- a/src/gui/sr-modal.tsx
+++ b/src/gui/sr-modal.tsx
@@ -1,4 +1,4 @@
-import { App, Modal, setIcon } from "obsidian";
+import { App, MarkdownView, Modal, setIcon } from "obsidian";
 
 import { Deck } from "src/deck";
 import {
@@ -79,6 +79,7 @@ export class FlashcardModal extends Modal {
             this.contentEl.createDiv(),
             this._showDecksList.bind(this),
             this._doEditQuestionText.bind(this),
+            this._jumpToCurrentCard.bind(this),
         );
     }
 
@@ -138,6 +139,31 @@ export class FlashcardModal extends Modal {
                 this.reviewSequencer.updateCurrentQuestionText(modifiedCardText);
             })
             .catch((reason) => console.log(reason));
+    }
+
+    private async _jumpToCurrentCard(): Promise<void> {
+        const currentQuestion = this.reviewSequencer.currentQuestion;
+        if (!currentQuestion) return;
+
+        const file = currentQuestion.note.file.tfile;
+        const blockId = currentQuestion.questionText.obsidianBlockId;
+        const line = Math.max(0, currentQuestion.lineNo ?? 0);
+
+        this.close();
+
+        if (blockId) {
+            await this.app.workspace.openLinkText(`${file.path}#${blockId}`, file.path, false);
+            return;
+        }
+
+        const leaf = this.app.workspace.getLeaf(false);
+        await leaf.openFile(file, { eState: { line } });
+
+        const markdownView = leaf.view as MarkdownView;
+        if (markdownView?.editor) {
+            markdownView.editor.setCursor({ line, ch: 0 });
+            markdownView.editor.scrollIntoView({ from: { line, ch: 0 }, to: { line, ch: 0 } });
+        }
     }
 
     private _createBackButton() {


### PR DESCRIPTION
Adds a new button to jump to where the card is in your notes for easy modification.

https://github.com/user-attachments/assets/8a50d7c7-9a0c-4e49-93fa-1789232ade36

An alternative solution would be a setting that overrides the editButton to jump to the note instead.

Closes #1228
