### PR TITLE
feat: add card deletion during review with confirmation logic and settings

### DIFF
--- a/docs/docs/en/flashcards/reviewing.md
+++ b/docs/docs/en/flashcards/reviewing.md
@@ -38,6 +38,7 @@ Although you may want to review or cram all cards across all decks, you often ma
 2 | Reset | Reset the review schedule information - the review interval is set to 1 day, and the ease is set to the default value
 3 | Info | Shows the scheduling information for the card
 4 | Skip | Skip the current card without reviewing
+5 | Delete | Delete the card from the note (Ctrl/Cmd + Click to force delete without confirmation)
 
 ### Context
 

--- a/src/data-stores/base/data-store.ts
+++ b/src/data-stores/base/data-store.ts
@@ -14,6 +14,7 @@ export interface IDataStore {
     questionRemoveScheduleInfo(questionText: string): string;
     questionWrite(question: Question): Promise<void>;
     questionWriteSchedule(question: Question): Promise<void>;
+    questionDelete(question: Question): Promise<void>;
 }
 
 export class DataStore {

--- a/src/data-stores/notes/notes.ts
+++ b/src/data-stores/notes/notes.ts
@@ -9,6 +9,7 @@ import { RepItemStorageInfo } from "src/data-stores/base/rep-item-storage-info";
 import { Question } from "src/question";
 import { SRSettings } from "src/settings";
 import { DateUtil, formatDateYYYYMMDD, globalDateProvider } from "src/utils/dates";
+import { MultiLineTextFinder } from "src/utils/strings";
 
 export class StoreInNotes implements IDataStore {
     private settings: SRSettings;
@@ -66,5 +67,21 @@ export class StoreInNotes implements IDataStore {
         const newText: string = question.updateQuestionWithinNoteText(fileText, this.settings);
         await question.note.file.write(newText);
         question.hasChanged = false;
+    }
+
+    async questionDelete(question: Question): Promise<void> {
+        const fileText: string = await question.note.file.read();
+        const originalText: string = question.questionText.original;
+        const newText = MultiLineTextFinder.findAndReplace(fileText, originalText, "");
+        if (newText) {
+            await question.note.file.write(newText);
+        } else {
+            console.error(
+                `questionDelete: Text not found: ${originalText.substring(
+                    0,
+                    100,
+                )} in note: ${fileText.substring(0, 100)}`,
+            );
+        }
     }
 }

--- a/src/flashcard-review-sequencer.ts
+++ b/src/flashcard-review-sequencer.ts
@@ -30,6 +30,7 @@ export interface IFlashcardReviewSequencer {
     determineCardSchedule(response: ReviewResponse, card: Card): RepItemScheduleInfo;
     processReview(response: ReviewResponse): Promise<void>;
     updateCurrentQuestionText(text: string): Promise<void>;
+    deleteCurrentCardFromNote(): Promise<void>;
 }
 
 /**
@@ -328,5 +329,12 @@ export class FlashcardReviewSequencer implements IFlashcardReviewSequencer {
         q.actualQuestion = text;
 
         await DataStore.getInstance().questionWrite(this.currentQuestion);
+    }
+
+    async deleteCurrentCardFromNote(): Promise<void> {
+        const question = this.currentQuestion;
+        await DataStore.getInstance().questionDelete(question);
+        this._originalDeckTree.deleteQuestionFromAllDecks(question, false);
+        this.cardSequencer.deleteCurrentQuestionFromAllDecks();
     }
 }

--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -62,6 +62,7 @@ export class CardUI {
     public resetButton: HTMLButtonElement;
     public infoButton: HTMLButtonElement;
     public skipButton: HTMLButtonElement;
+    public deleteButton: HTMLButtonElement;
 
     public response: HTMLDivElement;
     public hardButton: HTMLButtonElement;
@@ -257,6 +258,9 @@ export class CardUI {
         this._createResetButton();
         this._createCardInfoButton();
         this._createSkipButton();
+        if (this.settings.showDeleteButton) {
+            this._createDeleteButton();
+        }
     }
 
     private _createEditButton() {
@@ -301,6 +305,36 @@ export class CardUI {
 
     private async _skipCurrentCard(): Promise<void> {
         this.reviewSequencer.skipCurrentCard();
+        await this._showNextCard();
+    }
+
+    private _createDeleteButton() {
+        this.deleteButton = this.controls.createEl("button");
+        this.deleteButton.addClasses(["sr-button", "sr-delete-button"]);
+        setIcon(this.deleteButton, "trash");
+        this.deleteButton.setAttribute("aria-label", t("DELETE_CARD"));
+        this.deleteButton.addEventListener("click", async (e) => {
+            await this._deleteCurrentCard(e.ctrlKey || e.metaKey);
+        });
+    }
+
+    private async _deleteCurrentCard(force: boolean = false): Promise<void> {
+        const timeNow = now();
+        if (
+            this.lastPressed &&
+            timeNow - this.lastPressed < this.plugin.data.settings.reviewButtonDelay
+        ) {
+            return;
+        }
+        this.lastPressed = timeNow;
+
+        if (!force) {
+            if (!window.confirm(t("DELETE_CARD_CONFIRMATION"))) {
+                return;
+            }
+        }
+
+        await this.reviewSequencer.deleteCurrentCardFromNote();
         await this._showNextCard();
     }
 

--- a/src/gui/settings.tsx
+++ b/src/gui/settings.tsx
@@ -669,6 +669,18 @@ export class SRSettingTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
+            .setName(t("SHOW_DELETE_BUTTON"))
+            .setDesc(t("SHOW_DELETE_BUTTON_DESC"))
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.data.settings.showDeleteButton)
+                    .onChange(async (value) => {
+                        this.plugin.data.settings.showDeleteButton = value;
+                        await this.plugin.savePluginData();
+                    }),
+            );
+
+        new Setting(containerEl)
             .setName(t("CARD_MODAL_HEIGHT_PERCENT"))
             .setDesc(t("CARD_MODAL_SIZE_PERCENT_DESC"))
             .addSlider((slider) =>

--- a/src/lang/locale/ar.ts
+++ b/src/lang/locale/ar.ts
@@ -226,4 +226,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/cz.ts
+++ b/src/lang/locale/cz.ts
@@ -231,4 +231,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -251,4 +251,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -21,6 +21,8 @@ export default {
     CURRENT_EASE_HELP_TEXT: "Current Ease: ",
     CURRENT_INTERVAL_HELP_TEXT: "Current Interval: ",
     CARD_GENERATED_FROM: "Generated from: ${notePath}",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "Open a note for review",
@@ -99,6 +101,8 @@ export default {
     SHOW_INTERVAL_IN_REVIEW_BUTTONS: "Show next review time in the review buttons",
     SHOW_INTERVAL_IN_REVIEW_BUTTONS_DESC:
         "Useful to know how far in the future your cards are being pushed.",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
     CARD_MODAL_HEIGHT_PERCENT: "Flashcard Height Percentage",
     CARD_MODAL_SIZE_PERCENT_DESC:
         "Should be set to 100% on mobile or if you have very large images",

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -238,4 +238,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/fr.ts
+++ b/src/lang/locale/fr.ts
@@ -239,4 +239,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/it.ts
+++ b/src/lang/locale/it.ts
@@ -242,4 +242,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/ja.ts
+++ b/src/lang/locale/ja.ts
@@ -235,4 +235,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/ko.ts
+++ b/src/lang/locale/ko.ts
@@ -232,4 +232,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/nl.ts
+++ b/src/lang/locale/nl.ts
@@ -245,4 +245,8 @@ export default {
     SEARCH: "Zoeken",
     PREVIOUS: "Vorige",
     NEXT: "Volgende",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/pl.ts
+++ b/src/lang/locale/pl.ts
@@ -236,4 +236,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/pt-br.ts
+++ b/src/lang/locale/pt-br.ts
@@ -238,4 +238,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/ru.ts
+++ b/src/lang/locale/ru.ts
@@ -245,4 +245,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/tr.ts
+++ b/src/lang/locale/tr.ts
@@ -234,4 +234,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -21,6 +21,8 @@ export default {
     CURRENT_EASE_HELP_TEXT: "目前掌握程度：",
     CURRENT_INTERVAL_HELP_TEXT: "目前间隔：",
     CARD_GENERATED_FROM: "生成自：${notePath}",
+    DELETE_CARD: "删除卡片",
+    DELETE_CARD_CONFIRMATION: "你确定要删除这张卡片吗？",
 
     // main.ts
     OPEN_NOTE_FOR_REVIEW: "打开一个笔记开始复习",
@@ -94,6 +96,8 @@ export default {
     SHOW_CARD_CONTEXT_DESC: "例如：标题 > 副标题 > 小标题 > ... > 小标题",
     SHOW_INTERVAL_IN_REVIEW_BUTTONS: "将下次复习时间显示在复习按钮",
     SHOW_INTERVAL_IN_REVIEW_BUTTONS_DESC: "了解你的卡片被推迟了多久对你很有用",
+    SHOW_DELETE_BUTTON: "显示删除按钮",
+    SHOW_DELETE_BUTTON_DESC: "在卡片复习界面添加删除按钮。",
     CARD_MODAL_HEIGHT_PERCENT: "卡片高度百分比",
     CARD_MODAL_SIZE_PERCENT_DESC: "请在移动端使用并需要浏览较大图片时设为100%",
     RESET_DEFAULT: "重置为默认",

--- a/src/lang/locale/zh-tw.ts
+++ b/src/lang/locale/zh-tw.ts
@@ -218,4 +218,8 @@ export default {
     SEARCH: "Search",
     PREVIOUS: "Previous",
     NEXT: "Next",
+    DELETE_CARD: "Delete Card",
+    DELETE_CARD_CONFIRMATION: "Are you sure you want to delete this card?",
+    SHOW_DELETE_BUTTON: "Show Delete button",
+    SHOW_DELETE_BUTTON_DESC: "Add a delete button to the card review UI.",
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,6 +45,7 @@ export interface SRSettings {
     flashcardGoodText: string;
     flashcardHardText: string;
     reviewButtonDelay: number;
+    showDeleteButton: boolean;
     openViewInNewTab: boolean;
 
     // algorithm
@@ -105,6 +106,7 @@ export const DEFAULT_SETTINGS: SRSettings = {
     flashcardGoodText: t("GOOD"),
     flashcardHardText: t("HARD"),
     reviewButtonDelay: 0,
+    showDeleteButton: false,
     openViewInNewTab: false,
 
     // algorithm

--- a/tests/unit/flashcard-review-sequencer-counters.test.ts
+++ b/tests/unit/flashcard-review-sequencer-counters.test.ts
@@ -1,0 +1,136 @@
+import { SrsAlgorithm } from "src/algorithms/base/srs-algorithm";
+import { Deck, DeckTreeFilter } from "src/deck";
+import {
+    CardOrder,
+    DeckOrder,
+    DeckTreeIterator,
+    IDeckTreeIterator,
+    IIteratorOrder,
+} from "src/deck-tree-iterator";
+import { CardDueDateHistogram } from "src/due-date-histogram";
+import {
+    FlashcardReviewMode,
+    FlashcardReviewSequencer,
+    IFlashcardReviewSequencer,
+} from "src/flashcard-review-sequencer";
+import { QuestionPostponementList } from "src/question-postponement-list";
+import { DEFAULT_SETTINGS, SRSettings } from "src/settings";
+import { TopicPath } from "src/topic-path";
+import { setupStaticDateProvider20230906 } from "src/utils/dates";
+
+import { UnitTestSRFile } from "./helpers/unit-test-file";
+import { unitTestSetupStandardDataStoreAlgorithm } from "./helpers/unit-test-setup";
+import { SampleItemDecks } from "./sample-items";
+
+const orderDueFirstSequential: IIteratorOrder = {
+    cardOrder: CardOrder.DueFirstSequential,
+    deckOrder: DeckOrder.PrevDeckComplete_Sequential,
+};
+
+class TestContext {
+    settings: SRSettings;
+    reviewMode: FlashcardReviewMode;
+    iteratorOrder: IIteratorOrder;
+    cardSequencer: IDeckTreeIterator;
+    reviewSequencer: IFlashcardReviewSequencer;
+    questionPostponementList: QuestionPostponementList;
+    dueDateFlashcardHistogram: CardDueDateHistogram;
+    file: UnitTestSRFile;
+    originalText: string;
+    fakeFilePath: string;
+
+    constructor(init?: Partial<TestContext>) {
+        Object.assign(this, init);
+    }
+
+    async setSequencerDeckTreeFromOriginalText(): Promise<Deck> {
+        const deckTree: Deck = await SampleItemDecks.createDeckFromFile(
+            this.file,
+            new TopicPath(["Root"]),
+        );
+        const remainingDeckTree = DeckTreeFilter.filterForRemainingCards(
+            this.questionPostponementList,
+            deckTree,
+            this.reviewMode,
+        );
+        this.reviewSequencer.setDeckTree(deckTree, remainingDeckTree);
+        return deckTree;
+    }
+
+    static Create(
+        iteratorOrder: IIteratorOrder,
+        reviewMode: FlashcardReviewMode,
+        settings: SRSettings,
+        text: string,
+    ): TestContext {
+        const settingsClone: SRSettings = { ...settings };
+        const cardSequencer: IDeckTreeIterator = new DeckTreeIterator(iteratorOrder, null);
+        unitTestSetupStandardDataStoreAlgorithm(settingsClone);
+        const cardPostponementList: QuestionPostponementList = new QuestionPostponementList(
+            null,
+            settingsClone,
+            [],
+        );
+        const dueDateFlashcardHistogram: CardDueDateHistogram = new CardDueDateHistogram();
+        const reviewSequencer: FlashcardReviewSequencer = new FlashcardReviewSequencer(
+            reviewMode,
+            cardSequencer,
+            settingsClone,
+            SrsAlgorithm.getInstance(),
+            cardPostponementList,
+            dueDateFlashcardHistogram,
+        );
+        const file: UnitTestSRFile = new UnitTestSRFile(text, "test-file");
+
+        const result: TestContext = new TestContext({
+            settings: settingsClone,
+            reviewMode,
+            iteratorOrder,
+            cardSequencer,
+            reviewSequencer,
+            questionPostponementList: cardPostponementList,
+            file,
+            originalText: text,
+        });
+        return result;
+    }
+}
+
+describe("FlashcardReviewSequencer - Bidirectional Deletion", () => {
+    beforeEach(() => {
+        setupStaticDateProvider20230906();
+    });
+
+    test("Deleting a bidirectional card removes both cards from queue", async () => {
+        // Q1 ::: A1 creates two cards: Q1->A1 and A1->Q1
+        const text: string = "#flashcards Q1:::A1";
+
+        const c: TestContext = TestContext.Create(
+            orderDueFirstSequential,
+            FlashcardReviewMode.Review,
+            DEFAULT_SETTINGS,
+            text,
+        );
+        await c.setSequencerDeckTreeFromOriginalText();
+
+        // Initial check
+        const initialStats = c.reviewSequencer.getDeckStats(
+            TopicPath.getTopicPathFromTag("#flashcards"),
+        );
+        // Both are new cards
+        expect(initialStats.newCount).toEqual(2);
+        expect(initialStats.cardsInQueueCount).toEqual(2);
+
+        // Delete the current card
+        await c.reviewSequencer.deleteCurrentCardFromNote();
+
+        // Check stats again
+        const statsAfterDelete = c.reviewSequencer.getDeckStats(
+            TopicPath.getTopicPathFromTag("#flashcards"),
+        );
+
+        // Should be 0
+        expect(statsAfterDelete.newCount).toEqual(0);
+        expect(statsAfterDelete.cardsInQueueCount).toEqual(0);
+    });
+});


### PR DESCRIPTION
This PR implements a new feature allowing users to delete cards directly from the Review UI. It includes safety measures to prevent accidental deletions and a global setting to toggle the feature's visibility.

### Key Changes

#### 1. UI Enhancements

* Added a **Delete** button to the Card UI, positioned to the right of the `SKIP` button.
* Integrated the button with the existing theme to ensure visual consistency.

#### 2. Interaction Logic

* **Standard Click:** Triggers a confirmation dialog to prevent accidental data loss.
* **Power User Shortcut:** Holding `Command` (Mac) or `Ctrl` (Windows/Linux) while clicking the Delete button will **bypass the confirmation** and execute the deletion immediately.

#### 3. Configuration & Settings

* Introduced a new configuration option: `Enable Delete Button`.
* **Default State:** Set to `False` (Disabled) to maintain the existing user experience unless explicitly opted-in.

#### 4. Internationalization & Documentation

* Added i18n strings for the Delete button, confirmation prompts, and settings labels.
* Updated relevant documentation to reflect the new functionality and keyboard shortcuts.