### PR TITLE
feat: Implemented a customizable start of day

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -17,7 +17,7 @@ import { Note } from "src/note/note";
 import { NoteFileLoader } from "src/note/note-file-loader";
 import { NoteReviewQueue } from "src/note/note-review-queue";
 import { SettingsUtil, SRSettings } from "src/settings";
-import { globalDateProvider } from "src/utils/dates";
+import { globalDateProvider, IDayBoundary } from "src/utils/dates";
 import { TextDirection } from "src/utils/strings";
 
 export interface IOsrVaultEvents {
@@ -82,6 +82,20 @@ export class OsrCore {
         this._questionPostponementList = questionPostponementList;
         this._dueDateFlashcardHistogram = new CardDueDateHistogram();
         this._dueDateNoteHistogram = new NoteDueDateHistogram();
+        try {
+            const startOfDayElements: string[] = this.settings.startOfDay.split(":");
+            if (startOfDayElements.length !== 3) {
+                throw new Error("Invalid format for start of day");
+            }
+            const dayBoundary: IDayBoundary = {
+                hour: parseInt(startOfDayElements[0]),
+                minute: parseInt(startOfDayElements[1]),
+                second: parseInt(startOfDayElements[2]),
+            };
+            globalDateProvider.setDayBoundary(dayBoundary);
+        } catch (e) {
+            console.error("Invalid format for start of day", e);
+        }
     }
 
     protected loadInit(): void {

--- a/src/lang/locale/ar.ts
+++ b/src/lang/locale/ar.ts
@@ -261,4 +261,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/cz.ts
+++ b/src/lang/locale/cz.ts
@@ -265,4 +265,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -287,4 +287,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -266,4 +266,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -273,4 +273,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/fr.ts
+++ b/src/lang/locale/fr.ts
@@ -273,4 +273,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/it.ts
+++ b/src/lang/locale/it.ts
@@ -276,4 +276,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/ja.ts
+++ b/src/lang/locale/ja.ts
@@ -269,4 +269,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/ko.ts
+++ b/src/lang/locale/ko.ts
@@ -266,4 +266,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/nl.ts
+++ b/src/lang/locale/nl.ts
@@ -279,4 +279,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/pl.ts
+++ b/src/lang/locale/pl.ts
@@ -270,4 +270,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/pt-br.ts
+++ b/src/lang/locale/pt-br.ts
@@ -272,4 +272,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/ru.ts
+++ b/src/lang/locale/ru.ts
@@ -279,4 +279,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/tr.ts
+++ b/src/lang/locale/tr.ts
@@ -268,4 +268,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/uk.ts
+++ b/src/lang/locale/uk.ts
@@ -272,4 +272,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -250,4 +250,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/lang/locale/zh-tw.ts
+++ b/src/lang/locale/zh-tw.ts
@@ -252,4 +252,9 @@ export default {
     CONFIRM_SCHEDULING_DATA_DELETION_OF_CURRENT_CARD:
         "Are you sure you want to delete the scheduling data from your current card? This action cannot be undone.",
     SCHEDULING_DATA_DELETION_IN_PROGRESS_OF_CURRENT_CARD: "Deleting the cards scheduling data...",
+
+    // Settings > Scheduling
+    START_OF_DAY: "Start of day",
+    START_OF_DAY_DESC: "The time at which the day begins (Format: HH:MM:SS, Default: 00:00:00)",
+    INVALID_START_OF_DAY_WARNING: "Invalid format for start of day",
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,6 +57,7 @@ export interface SRSettings {
     loadBalance: boolean;
     maximumInterval: number;
     maxLinkFactor: number;
+    startOfDay: string;
 
     // storage
     dataStore: string;
@@ -121,6 +122,7 @@ export const DEFAULT_SETTINGS: SRSettings = {
     loadBalance: true,
     maximumInterval: 36525,
     maxLinkFactor: 1.0,
+    startOfDay: "00:00:00",
 
     // storage
     dataStore: DataStoreName.NOTES,

--- a/src/ui/obsidian-ui-components/content-container/settings-page/scheduling-page.tsx
+++ b/src/ui/obsidian-ui-components/content-container/settings-page/scheduling-page.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_SETTINGS } from "src/settings";
 import { SettingsPage } from "src/ui/obsidian-ui-components/content-container/settings-page/settings-page";
 import { SettingsPageType } from "src/ui/obsidian-ui-components/content-container/settings-page/settings-page-manager";
 import { ConfirmationModal } from "src/ui/obsidian-ui-components/modals/confirmation-modal";
+import { DateUtil, globalDateProvider, IDayBoundary } from "src/utils/dates";
 
 /**
  * Represents a scheduling settings page.
@@ -217,6 +218,39 @@ export class SchedulingPage extends SettingsPage {
                                     }
                                 });
                             }),
+                    );
+            })
+            .addSetting((setting: Setting) => {
+                setting
+                    .setName(t("START_OF_DAY"))
+                    .setDesc(t("START_OF_DAY_DESC"))
+                    .addExtraButton((button) => {
+                        button
+                            .setIcon("reset")
+                            .setTooltip(t("RESET_DEFAULT"))
+                            .onClick(async () => {
+                                this.plugin.data.settings.startOfDay = DEFAULT_SETTINGS.startOfDay;
+                                await this.plugin.savePluginData();
+
+                                this.display();
+                            });
+                    })
+                    .addText((text) =>
+                        text.setValue(this.plugin.data.settings.startOfDay).onChange((value) => {
+                            applySettingsUpdate(async () => {
+                                const dayBoundary: IDayBoundary | null =
+                                    DateUtil.strToDayBoundary(value);
+                                if (dayBoundary === null) {
+                                    new Notice(t("INVALID_START_OF_DAY_WARNING"));
+                                    return;
+                                } else {
+                                    this.plugin.data.settings.startOfDay = value;
+                                    await this.plugin.savePluginData();
+                                    globalDateProvider.setDayBoundary(dayBoundary);
+                                    console.log("Day boundary set to", dayBoundary);
+                                }
+                            });
+                        }),
                     );
             })
             .addSetting((setting: Setting) => {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -82,20 +82,62 @@ export function formatDate(
 export interface IDateProvider {
     get now(): Moment;
     get today(): Moment;
+    getDayBoundary(): IDayBoundary | null;
+    setDayBoundary(dayBoundary: IDayBoundary | null): void;
+}
+
+export interface IDayBoundary {
+    hour: number;
+    minute: number;
+    second: number;
 }
 
 export class LiveDateProvider implements IDateProvider {
+    private dayBoundary: IDayBoundary | null = null;
+
     get now(): Moment {
         return moment();
     }
 
     get today(): Moment {
-        return moment().startOf("day");
+        let result: Moment = moment().startOf("day");
+
+        // Skip to old today behavior if dayBoundary is set and it is midnight to avoid day boundary issues
+        if (
+            this.dayBoundary &&
+            this.dayBoundary.hour !== 0 &&
+            this.dayBoundary.minute !== 0 &&
+            this.dayBoundary.second !== 0
+        ) {
+            const nowTime = moment();
+            const customDayBoundary = moment()
+                .hour(this.dayBoundary.hour)
+                .minute(this.dayBoundary.minute)
+                .second(this.dayBoundary.second)
+                .millisecond(0);
+
+            if (nowTime.isBefore(customDayBoundary)) {
+                result = moment().startOf("day").subtract(1, "day");
+            } else {
+                result = moment().startOf("day");
+            }
+        }
+
+        return result;
+    }
+
+    getDayBoundary(): IDayBoundary | null {
+        return this.dayBoundary;
+    }
+
+    setDayBoundary(dayBoundary: IDayBoundary | null): void {
+        this.dayBoundary = dayBoundary;
     }
 }
 
 export class StaticDateProvider implements IDateProvider {
     private moment: Moment;
+    private dayBoundary: IDayBoundary | null = null;
 
     constructor(moment: Moment) {
         this.moment = moment;
@@ -112,11 +154,48 @@ export class StaticDateProvider implements IDateProvider {
     static fromDateStr(str: string): StaticDateProvider {
         return new StaticDateProvider(DateUtil.dateStrToMoment(str));
     }
+
+    getDayBoundary(): IDayBoundary | null {
+        return this.dayBoundary;
+    }
+
+    setDayBoundary(dayBoundary: IDayBoundary | null): void {
+        this.dayBoundary = dayBoundary;
+    }
 }
 
 export class DateUtil {
     static dateStrToMoment(str: string): Moment {
         return moment(str, ALLOWED_DATE_FORMATS);
+    }
+
+    static strToDayBoundary(str: string): IDayBoundary | null {
+        const dayStr: string[] = str.split(":");
+        if (dayStr.length !== 3) {
+            return null;
+        }
+
+        const hour: number = parseInt(dayStr[0]);
+        if (hour < 0 || hour > 23 || Number.isNaN(hour)) {
+            return null;
+        }
+
+        const minute: number = parseInt(dayStr[1]);
+        if (minute < 0 || minute > 59 || Number.isNaN(minute)) {
+            return null;
+        }
+
+        const second: number = parseInt(dayStr[2]);
+        if (second < 0 || second > 59 || Number.isNaN(second)) {
+            return null;
+        }
+
+        const dayBoundary: IDayBoundary = {
+            hour: hour,
+            minute: minute,
+            second: second,
+        };
+        return dayBoundary;
     }
 }
 


### PR DESCRIPTION
This PR implements a setting to set when the next day begins.

Examples:

Today is March 04 22:05
The start of day is set to 23:00
-> All cards for the due date of March 04 will only be shown after 23:00 on March 04


Today is March 04 01:05
The start of day is set to 03:00
-> All cards for the due date of March 05 will only be shown after 03:00 on March 05


Closes #1390 