### PR TITLE
fix: close modal on jump

### DIFF
--- a/src/lang/base-locale.ts
+++ b/src/lang/base-locale.ts
@@ -25,6 +25,9 @@ export interface IBaseLocale {
     CURRENT_EASE_HELP_TEXT: string;
     CURRENT_INTERVAL_HELP_TEXT: string;
     CARD_GENERATED_FROM: string;
+    JUMP_TO: string;
+    JUMP_TO_AND_CLOSE: string;
+    OPEN_IN_BACKGROUND: string;
     VIEW_CARD_INFO: string;
 
     // main.ts

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -29,6 +29,9 @@ const en: IBaseLocale = {
     CURRENT_EASE_HELP_TEXT: "Current Ease: ",
     CURRENT_INTERVAL_HELP_TEXT: "Current Interval: ",
     CARD_GENERATED_FROM: "Generated from: ${notePath}",
+    JUMP_TO: "Jump to card",
+    JUMP_TO_AND_CLOSE: "Close and jump to card",
+    OPEN_IN_BACKGROUND: "Open card in background",
     VIEW_CARD_INFO: "View Card Info",
     DELETE_CARD: "Delete Card",
     DELETE_CARD_CONFIRMATION:

--- a/src/ui/obsidian-ui-components/content-container/card-container/toolbar/toolbar.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/toolbar/toolbar.tsx
@@ -75,13 +75,34 @@ export default class CardToolbarComponent {
             (evt: MouseEvent) => {
                 const cardMenu = new Menu();
 
-                cardMenu.addItem((item) => {
-                    item.setTitle("Jump to card") // TODO: Translate
-                        .setIcon("arrow-up-right")
-                        .onClick(() => {
-                            jumpToCurrentCard();
-                        });
-                });
+                if (isModal) {
+                    cardMenu.addItem((item) => {
+                        item.setTitle(t("OPEN_IN_BACKGROUND"))
+                            .setIcon("browser-window")
+                            .onClick(() => {
+                                // Doesn't close modal, just opens in background and focuses
+                                jumpToCurrentCard();
+                            });
+                    });
+                    cardMenu.addItem((item) => {
+                        item.setTitle(t("JUMP_TO_AND_CLOSE"))
+                            .setIcon("arrow-up-right")
+                            .onClick(() => {
+                                jumpToCurrentCard();
+                                if (closeModal) {
+                                    closeModal();
+                                }
+                            });
+                    });
+                } else {
+                    cardMenu.addItem((item) => {
+                        item.setTitle(t("JUMP_TO"))
+                            .setIcon("arrow-up-right")
+                            .onClick(() => {
+                                jumpToCurrentCard();
+                            });
+                    });
+                }
                 cardMenu.addItem((item) => {
                     item.setTitle(t("VIEW_CARD_INFO"))
                         .setIcon("info")
@@ -170,11 +191,7 @@ export default class CardToolbarComponent {
             EmulatedPlatform().isPhone || Platform.isPhone ? "mod-raised" : "clickable-icon",
         ];
 
-        new ModalCloseButtonComponent(
-            this.toolbar,
-            () => closeModal && closeModal(),
-            closeButtonClasses,
-        );
+        new ModalCloseButtonComponent(this.toolbar, closeModal, closeButtonClasses);
     }
 
     /**

--- a/src/ui/obsidian-ui-components/content-container/card-container/toolbar/toolbar.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/toolbar/toolbar.tsx
@@ -78,7 +78,7 @@ export default class CardToolbarComponent {
                 if (isModal) {
                     cardMenu.addItem((item) => {
                         item.setTitle(t("OPEN_IN_BACKGROUND"))
-                            .setIcon("browser-window")
+                            .setIcon("send-to-back")
                             .onClick(() => {
                                 // Doesn't close modal, just opens in background and focuses
                                 jumpToCurrentCard();


### PR DESCRIPTION
Closes modal when jumping to a card.
Adds translation for card.

Also fixes "undefined" was string instead of actual undefined.