### PR TITLE
fix: fix "Jump to cart" feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,14 @@
 # vscode
 .vscode
 
+# devcontainer
+.devcontainer
+
 # npm
 node_modules
+
+# pnpm
+.pnpm-store
 
 # yarn
 yarn-error.log
@@ -20,6 +26,8 @@ yarn-error.log
 
 # build
 build
+main.js
+data.json
 
 # testing
 coverage

--- a/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
@@ -356,7 +356,7 @@ export class CardContainer {
 
         this.clozeInputs.forEach((input) => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            input.addEventListener("change", (e) => { });
+            input.addEventListener("change", (e) => {});
         });
     }
 

--- a/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
@@ -299,6 +299,23 @@ export class CardContainer {
             return;
         }
 
+        // If the file is already open in another leaf, open it in the current one to prevent duplicates
+        const existingLeaf = this.app.workspace.getLeavesOfType("markdown").find((leaf) => {
+            const view = leaf.view as MarkdownView;
+            return view.file?.path === file.path;
+        });
+
+        if (existingLeaf) {
+            await existingLeaf.openFile(file, { eState: { line } });
+            this.app.workspace.setActiveLeaf(existingLeaf);
+            const markdownView = existingLeaf.view as MarkdownView;
+            if (markdownView?.editor) {
+                markdownView.editor.setCursor({ line, ch: 0 });
+                markdownView.editor.scrollIntoView({ from: { line, ch: 0 }, to: { line, ch: 0 } });
+            }
+            return;
+        }
+
         const leaf = this.app.workspace.getLeaf("tab");
         await leaf.openFile(file, { eState: { line } });
 
@@ -339,7 +356,7 @@ export class CardContainer {
 
         this.clozeInputs.forEach((input) => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            input.addEventListener("change", (e) => {});
+            input.addEventListener("change", (e) => { });
         });
     }
 


### PR DESCRIPTION
This PR fixes an issue with the "Jump to card" feature by preventing duplicate tabs from opening for the same file. Now, if a file is already opened in another tab (leaf), it will be focused and scrolled to the correct line instead of opening a new tab.
