### PR TITLE
feat: add "tags to ignore" for flashcards and notes

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -115,10 +115,12 @@ export class OsrCore {
         // (Performance note: This only requires accessing Obsidian's metadata cache and not loading the file)
         this.osrNoteGraph.processLinks(noteFile.path);
 
+        const tags = noteFile.getAllTagsFromCache();
+
         // Does the note contain any tags that are specified as flashcard tags in the settings
         // (Doing this check first saves us from loading and parsing the note if not necessary)
         const topicPath: TopicPath = this.findTopicPath(noteFile);
-        if (topicPath.hasPath) {
+        if (topicPath.hasPath && !SettingsUtil.isAnyTagIgnoredForFlashcards(this.settings, tags)) {
             note = await this.loadNote(noteFile, topicPath);
             if (note !== null) note.appendCardsToDeck(this.fullDeckTree);
         }
@@ -128,10 +130,11 @@ export class OsrCore {
         // TODO:  should this move to this.loadNote
         SrsAlgorithm.getInstance().noteOnLoadedNote(noteFile.path, note, schedule?.latestEase);
 
-        const tags = noteFile.getAllTagsFromCache();
-
         const matchedNoteTags = SettingsUtil.filterForNoteReviewTag(this.settings, tags);
         if (matchedNoteTags.length === 0) {
+            return;
+        }
+        if (SettingsUtil.isAnyTagIgnoredForNotes(this.settings, tags)) {
             return;
         }
         const noteSchedule: RepItemScheduleInfo = await noteFile.getNoteSchedule();

--- a/src/lang/base-locale.ts
+++ b/src/lang/base-locale.ts
@@ -89,6 +89,8 @@ export interface IBaseLocale {
     REVIEW_BUTTON_DELAY_DESC: string;
     FLASHCARD_TAGS: string;
     FLASHCARD_TAGS_DESC: string;
+    FLASHCARD_TAGS_TO_IGNORE: string;
+    FLASHCARD_TAGS_TO_IGNORE_DESC: string;
     CONVERT_FOLDERS_TO_DECKS: string;
     CONVERT_FOLDERS_TO_DECKS_DESC: string;
     INLINE_SCHEDULING_COMMENTS: string;
@@ -136,6 +138,8 @@ export interface IBaseLocale {
     REVIEW_PANE_ON_STARTUP: string;
     TAGS_TO_REVIEW: string;
     TAGS_TO_REVIEW_DESC: string;
+    NOTE_TAGS_TO_IGNORE: string;
+    NOTE_TAGS_TO_IGNORE_DESC: string;
     OPEN_RANDOM_NOTE: string;
     OPEN_RANDOM_NOTE_DESC: string;
     AUTO_NEXT_NOTE: string;

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -103,6 +103,9 @@ const en: IBaseLocale = {
     FLASHCARD_TAGS: "Flashcard tags",
     FLASHCARD_TAGS_DESC:
         "Enter tags separated by spaces or newlines i.e. #flashcards #deck2 #deck3.",
+    FLASHCARD_TAGS_TO_IGNORE: "Tags to ignore",
+    FLASHCARD_TAGS_TO_IGNORE_DESC:
+        "Enter tags separated by spaces or newlines. Notes containing any of these tags will be excluded from flashcard review.",
     CONVERT_FOLDERS_TO_DECKS: "Convert folders to decks and subdecks",
     CONVERT_FOLDERS_TO_DECKS_DESC: "This is an alternative to the Flashcard tags option above.",
     INLINE_SCHEDULING_COMMENTS:
@@ -165,6 +168,9 @@ const en: IBaseLocale = {
     REVIEW_PANE_ON_STARTUP: "Enable note review pane on startup",
     TAGS_TO_REVIEW: "Tags to review",
     TAGS_TO_REVIEW_DESC: "Enter tags separated by spaces or newlines i.e. #review #tag2 #tag3.",
+    NOTE_TAGS_TO_IGNORE: "Tags to ignore",
+    NOTE_TAGS_TO_IGNORE_DESC:
+        "Enter tags separated by spaces or newlines. Notes containing any of these tags will be excluded from note review.",
     OPEN_RANDOM_NOTE: "Open a random note for review",
     OPEN_RANDOM_NOTE_DESC: "When you turn this off, notes are ordered by importance (PageRank).",
     AUTO_NEXT_NOTE: "Open next note automatically after a review",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import { pathMatchesPattern } from "src/utils/fs";
 export interface SRSettings {
     // flashcards
     flashcardTags: string[];
+    flashcardTagsToIgnore: string[];
     convertFoldersToDecks: boolean;
     burySiblingCards: boolean;
     randomizeCardOrder: boolean | undefined;
@@ -26,6 +27,7 @@ export interface SRSettings {
     // notes
     enableNoteReviewPaneOnStartup: boolean;
     tagsToReview: string[];
+    noteTagsToIgnore: string[];
     noteFoldersToIgnore: string[];
     openRandomNote: boolean;
     autoNextNote: boolean;
@@ -80,6 +82,7 @@ export interface SRSettings {
 export const DEFAULT_SETTINGS: SRSettings = {
     // flashcards
     flashcardTags: ["#flashcards"],
+    flashcardTagsToIgnore: [],
     convertFoldersToDecks: false,
     burySiblingCards: false,
     flashcardCardOrder: "DueFirstRandom",
@@ -100,6 +103,7 @@ export const DEFAULT_SETTINGS: SRSettings = {
     // notes
     enableNoteReviewPaneOnStartup: true,
     tagsToReview: ["#review"],
+    noteTagsToIgnore: [],
     noteFoldersToIgnore: ["**/*.excalidraw.md"],
     openRandomNote: false,
     autoNextNote: false,
@@ -205,6 +209,14 @@ export class SettingsUtil {
             }
         }
         return false;
+    }
+
+    static isAnyTagIgnoredForFlashcards(settings: SRSettings, tags: string[]): boolean {
+        return tags.some((tag) => SettingsUtil.isTagInList(settings.flashcardTagsToIgnore, tag));
+    }
+
+    static isAnyTagIgnoredForNotes(settings: SRSettings, tags: string[]): boolean {
+        return tags.some((tag) => SettingsUtil.isTagInList(settings.noteTagsToIgnore, tag));
     }
 
     // Given a list of tags, return the subset that is in settings.tagsToReview

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -230,7 +230,15 @@ export class SettingsUtil {
         return result;
     }
 
-    private static isTagInList(
+    /**
+     * Checks if the tag is in the tagList.
+     *
+     * @param tagList - The list of tags to check.
+     * @param tag - The tag to check.
+     * @param exactMatch - Whether to match the tag exactly or if it should be a sub tag.
+     * @returns true if the tag is in the tagList, false otherwise.
+     */
+    public static isTagInList(
         tagList: string[],
         tag: string,
         exactMatch: boolean = false,
@@ -253,7 +261,14 @@ export class SettingsUtil {
         return false;
     }
 
-    private static isSubTagContainedInTag(tag: string, subTag: string): boolean {
+    /**
+     * Checks if the subTag is contained in the tag.
+     *
+     * @param tag - The tag to check.
+     * @param subTag - The subTag to check.
+     * @returns true if the subTag is contained in the tag, false otherwise.
+     */
+    public static isSubTagContainedInTag(tag: string, subTag: string): boolean {
         if (tag === subTag || subTag.startsWith(tag + "/")) {
             // The tag is the same as the sub tag, or the sub tag is contained in the tag
             return true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -201,8 +201,8 @@ export class SettingsUtil {
     static isAnyTagANoteReviewTag(settings: SRSettings, tags: string[]): boolean {
         for (const tag of tags) {
             if (
-                settings.tagsToReview.some(
-                    (tagToReview) => tag === tagToReview || tag.startsWith(tagToReview + "/"),
+                settings.tagsToReview.some((tagToReview) =>
+                    this.isSubTagContainedInTag(tagToReview, tag),
                 )
             ) {
                 return true;
@@ -223,18 +223,40 @@ export class SettingsUtil {
     static filterForNoteReviewTag(settings: SRSettings, tags: string[]): string[] {
         const result: string[] = [];
         for (const tagToReview of settings.tagsToReview) {
-            if (tags.some((tag) => tag === tagToReview || tag.startsWith(tagToReview + "/"))) {
+            if (tags.some((tag) => this.isSubTagContainedInTag(tagToReview, tag))) {
                 result.push(tagToReview);
             }
         }
         return result;
     }
 
-    private static isTagInList(tagList: string[], tag: string): boolean {
+    private static isTagInList(
+        tagList: string[],
+        tag: string,
+        exactMatch: boolean = false,
+    ): boolean {
+        // This should be true, if the tag is fully contained in a tag from the list
         for (const tagFromList of tagList) {
-            if (tag === tagFromList || tag.startsWith(tagFromList + "/")) {
-                return true;
+            if (exactMatch) {
+                if (tagFromList === tag) {
+                    // The tag from the list is the same as the current tag, so it is contained in it
+                    return true;
+                }
+            } else {
+                // In this case we need to look more in detail to see if the tag is fully contained in the tag from the list
+                if (this.isSubTagContainedInTag(tagFromList, tag)) {
+                    // The tag from the list is contained in the current tag, so it is contained in it
+                    return true;
+                }
             }
+        }
+        return false;
+    }
+
+    private static isSubTagContainedInTag(tag: string, subTag: string): boolean {
+        if (tag === subTag || subTag.startsWith(tag + "/")) {
+            // The tag is the same as the sub tag, or the sub tag is contained in the tag
+            return true;
         }
         return false;
     }

--- a/src/ui/obsidian-ui-components/content-container/settings-page/flashcards-page.tsx
+++ b/src/ui/obsidian-ui-components/content-container/settings-page/flashcards-page.tsx
@@ -80,6 +80,23 @@ export class FlashcardsPage extends SettingsPage {
             })
             .addSetting((setting: Setting) => {
                 setting
+                    .setName(t("FLASHCARD_TAGS_TO_IGNORE"))
+                    .setDesc(t("FLASHCARD_TAGS_TO_IGNORE_DESC"))
+                    .addTextArea((text) =>
+                        text
+                            .setValue(this.plugin.data.settings.flashcardTagsToIgnore.join(" "))
+                            .onChange((value) => {
+                                applySettingsUpdate(async () => {
+                                    this.plugin.data.settings.flashcardTagsToIgnore = value
+                                        .split(/\s+/)
+                                        .filter((v) => v);
+                                    await this.plugin.savePluginData();
+                                });
+                            }),
+                    );
+            })
+            .addSetting((setting: Setting) => {
+                setting
                     .setName(t("FOLDERS_TO_IGNORE"))
                     .setDesc(t("FOLDERS_TO_IGNORE_DESC"))
                     .addTextArea((text) =>

--- a/src/ui/obsidian-ui-components/content-container/settings-page/notes-page.tsx
+++ b/src/ui/obsidian-ui-components/content-container/settings-page/notes-page.tsx
@@ -80,8 +80,6 @@ export class NotesPage extends SettingsPage {
                                         .map((v) => v.trim())
                                         .filter((v) => v);
                                     await this.plugin.savePluginData();
-
-                                    this.display();
                                 });
                             }),
                     );

--- a/src/ui/obsidian-ui-components/content-container/settings-page/notes-page.tsx
+++ b/src/ui/obsidian-ui-components/content-container/settings-page/notes-page.tsx
@@ -51,6 +51,23 @@ export class NotesPage extends SettingsPage {
             })
             .addSetting((setting: Setting) => {
                 setting
+                    .setName(t("NOTE_TAGS_TO_IGNORE"))
+                    .setDesc(t("NOTE_TAGS_TO_IGNORE_DESC"))
+                    .addTextArea((text) =>
+                        text
+                            .setValue(this.plugin.data.settings.noteTagsToIgnore.join(" "))
+                            .onChange((value) => {
+                                applySettingsUpdate(async () => {
+                                    this.plugin.data.settings.noteTagsToIgnore = value
+                                        .split(/\s+/)
+                                        .filter((v) => v);
+                                    await this.plugin.savePluginData();
+                                });
+                            }),
+                    );
+            })
+            .addSetting((setting: Setting) => {
+                setting
                     .setName(t("FOLDERS_TO_IGNORE"))
                     .setDesc(t("FOLDERS_TO_IGNORE_DESC"))
                     .addTextArea((text) =>

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -14,6 +14,42 @@ describe("SettingsUtil", () => {
         expect(SettingsUtil.isAnyTagANoteReviewTag(settings, ["#test"])).toEqual(false);
     });
 
+    test("isAnyTagIgnoredForFlashcards", () => {
+        const settings: SRSettings = {
+            ...DEFAULT_SETTINGS,
+            flashcardTagsToIgnore: ["#archived"],
+        };
+        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#archived"])).toEqual(true);
+        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#archived/old"])).toEqual(
+            true,
+        );
+        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#flashcards"])).toEqual(false);
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#flashcards", "#archived"]),
+        ).toEqual(true);
+        const settingsNoIgnore: SRSettings = { ...DEFAULT_SETTINGS, flashcardTagsToIgnore: [] };
+        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settingsNoIgnore, ["#archived"])).toEqual(
+            false,
+        );
+    });
+
+    test("isAnyTagIgnoredForNotes", () => {
+        const settings: SRSettings = {
+            ...DEFAULT_SETTINGS,
+            noteTagsToIgnore: ["#archived"],
+        };
+        expect(SettingsUtil.isAnyTagIgnoredForNotes(settings, ["#archived"])).toEqual(true);
+        expect(SettingsUtil.isAnyTagIgnoredForNotes(settings, ["#archived/old"])).toEqual(true);
+        expect(SettingsUtil.isAnyTagIgnoredForNotes(settings, ["#review"])).toEqual(false);
+        expect(SettingsUtil.isAnyTagIgnoredForNotes(settings, ["#review", "#archived"])).toEqual(
+            true,
+        );
+        const settingsNoIgnore: SRSettings = { ...DEFAULT_SETTINGS, noteTagsToIgnore: [] };
+        expect(SettingsUtil.isAnyTagIgnoredForNotes(settingsNoIgnore, ["#archived"])).toEqual(
+            false,
+        );
+    });
+
     test("upgradeSettings", () => {
         let settings: SRSettings = { ...DEFAULT_SETTINGS };
         upgradeSettings(settings);

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -15,22 +15,99 @@ describe("SettingsUtil", () => {
     });
 
     test("isAnyTagIgnoredForFlashcards", () => {
-        const settings: SRSettings = {
+        const simpleDeckSettings: SRSettings = {
             ...DEFAULT_SETTINGS,
             flashcardTagsToIgnore: ["#archived"],
         };
-        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#archived"])).toEqual(true);
-        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#archived/old"])).toEqual(
-            true,
-        );
-        expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#flashcards"])).toEqual(false);
         expect(
-            SettingsUtil.isAnyTagIgnoredForFlashcards(settings, ["#flashcards", "#archived"]),
+            SettingsUtil.isAnyTagIgnoredForFlashcards(simpleDeckSettings, ["#archived"]),
         ).toEqual(true);
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(simpleDeckSettings, ["#archived/old"]),
+        ).toEqual(true);
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(simpleDeckSettings, ["#flashcards"]),
+        ).toEqual(false);
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(simpleDeckSettings, [
+                "#flashcards",
+                "#archived",
+            ]),
+        ).toEqual(true);
+
         const settingsNoIgnore: SRSettings = { ...DEFAULT_SETTINGS, flashcardTagsToIgnore: [] };
         expect(SettingsUtil.isAnyTagIgnoredForFlashcards(settingsNoIgnore, ["#archived"])).toEqual(
             false,
         );
+
+        const complexDeckSettings: SRSettings = {
+            ...DEFAULT_SETTINGS,
+            flashcardTagsToIgnore: [
+                "#archived",
+                "#flashcards/Capitals/europa",
+                "#flashcards/Capitals/africa/test/test/test",
+            ],
+        };
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals",
+            ]),
+        ).toEqual(false);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/test",
+            ]),
+        ).toEqual(false);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/europa",
+            ]),
+        ).toEqual(true);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/europa/germany",
+            ]),
+        ).toEqual(true);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/eu",
+            ]),
+        ).toEqual(false);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/eu/germany",
+            ]),
+        ).toEqual(false);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/africa/test",
+            ]),
+        ).toEqual(false);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/africa/test/test",
+            ]),
+        ).toEqual(false);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/africa/test/test/test",
+            ]),
+        ).toEqual(true);
+
+        expect(
+            SettingsUtil.isAnyTagIgnoredForFlashcards(complexDeckSettings, [
+                "#flashcards/Capitals/africa/test/test/test/test/test",
+            ]),
+        ).toEqual(true);
     });
 
     test("isAnyTagIgnoredForNotes", () => {

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -108,6 +108,22 @@ describe("SettingsUtil", () => {
                 "#flashcards/Capitals/africa/test/test/test/test/test",
             ]),
         ).toEqual(true);
+
+        expect(
+            SettingsUtil.isTagInList(
+                complexDeckSettings.flashcardTagsToIgnore,
+                "#flashcards/Capitals/africa/test/test/test",
+                true,
+            ),
+        ).toEqual(true);
+
+        expect(
+            SettingsUtil.isTagInList(
+                complexDeckSettings.flashcardTagsToIgnore,
+                "#flashcards/Capitals/africa/test/test/test/test",
+                true,
+            ),
+        ).toEqual(false);
     });
 
     test("isAnyTagIgnoredForNotes", () => {


### PR DESCRIPTION
Adds a "Tags to ignore" field in both the Flashcards and Notes settings pages, right before "Folders to ignore". Notes carrying any of the specified tags are fully skipped — no cards loaded, no notes added to the review queue.

This is useful when some notes match an include tag but shouldn't be reviewed yet — drafts, archived material, work-in-progress decks — without touching the notes themselves. Both fields use the same prefix-matching as the include-tag fields, so `#archived` also covers `#archived/old`.

Closes #737, #1121, #1186



---

I'm aware of #1244 which addresses the same issue, but the behavior is different: it excludes tags from deck creation while the cards still appear in review. This PR goes for full exclusion, which I think matches the intent of #737 more closely. It also extends the same idea to the note review queue, which #1244 doesn't cover.

The implementation follows the current v1.14.1 architecture, all existing tests pass, and the linter is happy. Unit tests for the new `SettingsUtil` helpers are included.