### PR TITLE
feat: support cloze deletions inside LaTeX math via \cloze macro

### DIFF
--- a/docs/docs/en/flashcards/cloze-cards.md
+++ b/docs/docs/en/flashcards/cloze-cards.md
@@ -63,6 +63,54 @@ The first female ==prime minister== of Australia was ==Julia Gillard==
 These two cards are considered sibling cards. See [sibling cards](flashcards-overview.md#sibling-cards) regarding the
 [Bury sibling cards until the next day](../user-options.md#flashcard-review) scheduling option.
 
+## Clozes in Math (LaTeX)
+
+Inside inline (`$...$`) or block (`$$...$$`) math, mark a cloze deletion with the `\cloze{answer}{hint}` macro.
+The other cloze delimiters are unsuitable inside math: `==` and `**` change the LaTeX rendering, and `{{...}}` collides with LaTeX's own use of braces.
+
+The hint is the second argument — leave it empty (`{}`) when you don't need one.
+
+When you **read** a note, `\cloze{answer}{hint}` renders as just the `answer`, so the formula looks normal.
+When you **review**, the answer is hidden on the front (shown as `[hint]`, or `[…]` when no hint is given) and revealed on the back.
+
+For instance, the following note:
+
+```
+$$
+\cloze{c^2}{} = \cloze{a^2 + b^2}{Pythagoras}
+$$
+```
+
+Generates two sibling cards, with the following fronts:
+
+!!! note ""
+
+    <div class="grid" markdown>
+
+    !!! tip "Card 1 Initial View"
+
+        $$ [\ldots] = a^2 + b^2 $$
+
+    !!! tip "Card 2 Initial View"
+
+        $$ c^2 = [\text{Pythagoras}] $$
+
+    </div>
+
+!!! tip "After `Show Answer` Clicked (same for both cards)"
+
+    $$ c^2 = a^2 + b^2 $$
+
+The answer may contain braces, fractions, roots, and other nested LaTeX — for example `\cloze{\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}}{}` — and is parsed correctly.
+
+!!! note
+
+    `\cloze` works inside math regardless of the cloze patterns configured in your settings. It does not need to be added to [Custom Cloze Patterns](#custom-cloze-patterns).
+
+!!! warning
+
+    A note that is already open when the plugin loads may show `\cloze` unrendered until its view is rebuilt: switch to another note and back, or reopen the note. Notes opened afterwards render correctly straight away.
+
 ## Cloze Types
 
 ### Simplified Clozes

--- a/src/data/data-structures/card/questions/math-cloze.ts
+++ b/src/data/data-structures/card/questions/math-cloze.ts
@@ -1,0 +1,118 @@
+// The `\cloze{answer}{hint}` LaTeX macro. Unlike `{{...}}`, this token never occurs in ordinary
+// LaTeX, so there are no false positives, and a global MathJax macro (registered in
+// cloze-math-macro.ts) renders it as the answer in normal preview. Here we parse it for flashcard
+// review: each `\cloze` becomes one sibling card whose answer is occluded on the front and
+// revealed (highlighted) on the back. Other clozes in the same note show their answer plainly.
+//
+// Returns bare { front, back } pairs (not CardFrontBack) so this stays a leaf module with no
+// dependency back on question-type.
+
+const CLOZE_COLOR = "#2196f3";
+
+interface MathCloze {
+    start: number; // index of the leading backslash
+    end: number; // index just past the closing brace of the hint arg
+    answer: string;
+    hint: string;
+}
+
+/**
+ * Whether `text` contains at least one `\cloze{...}{...}` macro.
+ *
+ * @param text - The text to test (a single line in the parser, or a whole card in expand)
+ * @returns True if a `\cloze{` macro is present
+ */
+export function containsMathCloze(text: string): boolean {
+    return /\\cloze\s*\{/.test(text);
+}
+
+/**
+ * Expand the `\cloze{answer}{hint}` macros in `text` into one flashcard per cloze.
+ *
+ * @param text - The card text, typically containing `$...$` / `$$...$$` math
+ * @returns One `{ front, back }` per cloze; on each card the target cloze is occluded on the
+ *     front and revealed (highlighted) on the back, while the other clozes show their answer
+ */
+export function expandMathClozes(text: string): { front: string; back: string }[] {
+    const clozes = findMathClozes(text);
+    const cards: { front: string; back: string }[] = [];
+    for (let target = 0; target < clozes.length; target++) {
+        cards.push({
+            front: renderCard(text, clozes, target, false),
+            back: renderCard(text, clozes, target, true),
+        });
+    }
+    return cards;
+}
+
+// Rebuild the card text, replacing each `\cloze{...}{...}` with its front/back rendering.
+function renderCard(
+    text: string,
+    clozes: MathCloze[],
+    targetIndex: number,
+    isBack: boolean,
+): string {
+    let out = "";
+    let cursor = 0;
+    for (let k = 0; k < clozes.length; k++) {
+        const cloze = clozes[k];
+        out += text.slice(cursor, cloze.start);
+        out += renderCloze(cloze, k === targetIndex, isBack);
+        cursor = cloze.end;
+    }
+    return out + text.slice(cursor);
+}
+
+function renderCloze(cloze: MathCloze, isTarget: boolean, isBack: boolean): string {
+    if (!isTarget) return cloze.answer; // shown normally on every card
+    if (isBack) return `\\color{${CLOZE_COLOR}}{${cloze.answer}}`; // revealed answer
+    const placeholder = cloze.hint.trim().length ? `[\\text{${cloze.hint.trim()}}]` : "[\\ldots]";
+    return `\\color{${CLOZE_COLOR}}{${placeholder}}`;
+}
+
+// Locate every `\cloze{answer}{hint}`, reading both arguments as balanced-brace groups.
+function findMathClozes(text: string): MathCloze[] {
+    const result: MathCloze[] = [];
+    const cmd = "\\cloze";
+    let i = text.indexOf(cmd);
+    while (i !== -1) {
+        const after = i + cmd.length;
+        // Reject `\clozeXYZ` (a TeX command name continues with letters).
+        if (/[a-zA-Z]/.test(text[after] ?? "")) {
+            i = text.indexOf(cmd, after);
+            continue;
+        }
+        const answer = readBraceGroup(text, after);
+        const hint = answer && readBraceGroup(text, answer.end);
+        if (answer && hint) {
+            result.push({ start: i, end: hint.end, answer: answer.content, hint: hint.content });
+            i = text.indexOf(cmd, hint.end);
+        } else {
+            i = text.indexOf(cmd, after);
+        }
+    }
+    return result;
+}
+
+// From `pos` (skipping whitespace), read a `{ ... }` group with balanced braces, ignoring escaped
+// braces (\{ \}). Returns the inner content and the index past the closing brace, or null.
+function readBraceGroup(text: string, pos: number): { content: string; end: number } | null {
+    let p = pos;
+    while (p < text.length && /\s/.test(text[p])) p++;
+    if (text[p] !== "{") return null;
+
+    let depth = 0;
+    for (let j = p; j < text.length; j++) {
+        const ch = text[j];
+        if (ch === "\\") {
+            j++; // skip the escaped character (\{ \} \\)
+            continue;
+        }
+        if (ch === "{") depth++;
+        else if (ch === "}") {
+            depth--;
+            if (depth === 0) return { content: text.slice(p + 1, j), end: j + 1 };
+        }
+    }
+    return null;
+}

--- a/src/data/data-structures/card/questions/question-type.ts
+++ b/src/data/data-structures/card/questions/question-type.ts
@@ -1,5 +1,9 @@
 import { ClozeCrafter, IClozeFormatter } from "clozecraft";
 
+import {
+    containsMathCloze,
+    expandMathClozes,
+} from "src/data/data-structures/card/questions/math-cloze";
 import { CardType } from "src/data/data-structures/card/questions/question";
 import { SRSettings } from "src/data/settings";
 import { findLineIndexOfSearchStringIgnoringWs } from "src/utils/strings";
@@ -94,6 +98,12 @@ class QuestionTypeMultiLineReversed implements IQuestionTypeHandler {
 
 class QuestionTypeCloze implements IQuestionTypeHandler {
     expand(questionText: string, settings: SRSettings): CardFrontBack[] {
+        // `\cloze{answer}{hint}` is parsed directly (collision-free LaTeX macro); everything else
+        // goes through clozecraft's configurable `{{...}}` / `==...==` patterns.
+        if (containsMathCloze(questionText)) {
+            return expandMathClozes(questionText).map((c) => new CardFrontBack(c.front, c.back));
+        }
+
         const clozecrafter = new ClozeCrafter(settings.clozePatterns);
         const clozeNote = clozecrafter.createClozeNote(questionText);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { LocaleManagerInstance } from "src/lang/locale-manager";
 import { NextNoteReviewHandler } from "src/note/next-note-review-handler";
 import { NoteReviewQueue } from "src/note/note-review-queue";
 import { ReminderManager } from "src/scheduling/reminder-manager";
+import { registerClozeMathMacro } from "src/ui/cloze-math-macro";
 import { REVIEW_QUEUE_VIEW_TYPE } from "src/ui/obsidian-ui-components/item-views/review-queue-list-view";
 import { UIManager } from "src/ui/ui-manager";
 import { TextDirection } from "src/utils/strings";
@@ -42,6 +43,9 @@ export default class SRPlugin extends Plugin {
             this.commandManager = new CommandManager(this, settingsManager, uiManager);
 
             this.app.workspace.onLayoutReady(async () => {
+                // Teach MathJax the \cloze macro so \cloze{answer}{hint} renders in note preview.
+                void registerClozeMathMacro();
+
                 this.dataManager.loadData();
 
                 // Set the preferred locale if it is not the default

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,7 @@
 import { ClozeCrafter } from "clozecraft";
 
 import { SR_METADATA_CALLOUT } from "src/data/constants";
+import { containsMathCloze } from "src/data/data-structures/card/questions/math-cloze";
 import { CardType } from "src/data/data-structures/card/questions/question";
 
 export let debugParser = false;
@@ -196,8 +197,11 @@ export function parse(text: string, options: ParserOptions): ParsedQuestionInfo[
             }
             cardText += "\n" + codeBlockClose;
             i++;
-        } else if (cardType === null && clozecrafter.isClozeNote(currentLine)) {
-            // Pick up cloze cards
+        } else if (
+            cardType === null &&
+            (clozecrafter.isClozeNote(currentLine) || containsMathCloze(currentLine))
+        ) {
+            // Pick up cloze cards (clozecraft patterns, or the \cloze{answer}{hint} LaTeX macro)
             cardType = CardType.Cloze;
         }
     }

--- a/src/ui/cloze-math-macro.ts
+++ b/src/ui/cloze-math-macro.ts
@@ -1,0 +1,26 @@
+import { finishRenderMath, loadMathJax, renderMath } from "obsidian";
+
+/**
+ * Makes `\cloze{answer}{hint}` render in ordinary Obsidian preview (Reading view + Live Preview).
+ *
+ * `\cloze` is not a real LaTeX command, so MathJax errors on `$\cloze{g(x)}{h}$` unless we teach
+ * it the macro. Obsidian's MathJax keeps TeX macro definitions for the whole session, so defining
+ * `\cloze` once here makes it available in every note. We use `\def` (not `\newcommand`) so a
+ * plugin reload doesn't error on redefinition. It expands to its first argument (the answer), so
+ * reading a note shows the full formula; the flashcard review path (see math-cloze.ts) renders the
+ * occluded/answer forms itself.
+ *
+ * Caveat: a note that is already open when the plugin loads keeps its earlier (macro-less) render
+ * until its view is rebuilt (switch to another note and back, or reopen it). Notes opened
+ * afterwards are fine.
+ */
+export async function registerClozeMathMacro(): Promise<void> {
+    await loadMathJax();
+    try {
+        // \def\cloze#1#2{#1} defines a 2-arg macro that expands to the first arg (the answer).
+        renderMath("\\def\\cloze#1#2{#1}", false);
+        await finishRenderMath();
+    } catch (e) {
+        console.warn("SR: failed to register \\cloze MathJax macro", e);
+    }
+}

--- a/tests/unit/data/math-cloze.test.ts
+++ b/tests/unit/data/math-cloze.test.ts
@@ -87,4 +87,14 @@ describe("expandMathClozes", () => {
         // No second {...} -> not a valid cloze -> no cards produced.
         expect(expandMathClozes("$\\cloze{a}$")).toEqual([]);
     });
+
+    test("\\clozeXYZ (command continues with letters) is not a cloze", () => {
+        // \clozenot is a different macro; the letter boundary rejects it.
+        expect(expandMathClozes("$\\clozenot{a}{b}$")).toEqual([]);
+    });
+
+    test("an unclosed brace group produces no card", () => {
+        // Second arg opens but never closes -> readBraceGroup returns null.
+        expect(expandMathClozes("$\\cloze{a}{b$")).toEqual([]);
+    });
 });

--- a/tests/unit/data/math-cloze.test.ts
+++ b/tests/unit/data/math-cloze.test.ts
@@ -1,0 +1,90 @@
+import {
+    containsMathCloze,
+    expandMathClozes,
+} from "src/data/data-structures/card/questions/math-cloze";
+import { CardType } from "src/data/data-structures/card/questions/question";
+import {
+    CardFrontBack,
+    CardFrontBackUtil,
+} from "src/data/data-structures/card/questions/question-type";
+import { DEFAULT_SETTINGS } from "src/data/settings";
+
+// Goes through the public expand() path to also cover the QuestionTypeCloze wiring.
+const expand = (text: string) => CardFrontBackUtil.expand(CardType.Cloze, text, DEFAULT_SETTINGS);
+
+describe("containsMathCloze", () => {
+    test.each([
+        ["$\\cloze{a}{b}$", true],
+        ["$\\cloze {a}{b}$", true],
+        ["plain {{a}} text", false],
+        ["$\\clozenot{a}{b}$", false], // command boundary: \clozenot is not \cloze
+        ["no math here", false],
+    ])("%s -> %s", (text, expected) => {
+        expect(containsMathCloze(text)).toBe(expected);
+    });
+});
+
+describe("expandMathClozes", () => {
+    test("inline cloze with hint", () => {
+        expect(expand("$f(x) = \\cloze{g(x)}{inner function}$")).toEqual([
+            new CardFrontBack(
+                "$f(x) = \\color{#2196f3}{[\\text{inner function}]}$",
+                "$f(x) = \\color{#2196f3}{g(x)}$",
+            ),
+        ]);
+    });
+
+    test("empty hint falls back to ellipsis placeholder", () => {
+        expect(expand("$$\\cloze{c^2}{} = a^2 + b^2$$")).toEqual([
+            new CardFrontBack(
+                "$$\\color{#2196f3}{[\\ldots]} = a^2 + b^2$$",
+                "$$\\color{#2196f3}{c^2} = a^2 + b^2$$",
+            ),
+        ]);
+    });
+
+    test("multiple clozes become sibling cards; non-targets show their answer", () => {
+        expect(expand("$$\\cloze{a^2}{} + \\cloze{b^2}{} = c^2$$")).toEqual([
+            new CardFrontBack(
+                "$$\\color{#2196f3}{[\\ldots]} + b^2 = c^2$$",
+                "$$\\color{#2196f3}{a^2} + b^2 = c^2$$",
+            ),
+            new CardFrontBack(
+                "$$a^2 + \\color{#2196f3}{[\\ldots]} = c^2$$",
+                "$$a^2 + \\color{#2196f3}{b^2} = c^2$$",
+            ),
+        ]);
+    });
+
+    test("nested braces (e^{x^{2}})", () => {
+        expect(expand("$$\\cloze{e^{x^{2}}}{} = 1$$")).toEqual([
+            new CardFrontBack(
+                "$$\\color{#2196f3}{[\\ldots]} = 1$$",
+                "$$\\color{#2196f3}{e^{x^{2}}} = 1$$",
+            ),
+        ]);
+    });
+
+    test("sqrt as last \\frac argument (adjacent inner braces)", () => {
+        expect(expand("$x = \\cloze{\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}}{}$")).toEqual([
+            new CardFrontBack(
+                "$x = \\color{#2196f3}{[\\ldots]}$",
+                "$x = \\color{#2196f3}{\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}}$",
+            ),
+        ]);
+    });
+
+    test("escaped braces in the answer (set notation)", () => {
+        expect(expand("$S = \\cloze{\\{x : x > 0\\}}{a set}$")).toEqual([
+            new CardFrontBack(
+                "$S = \\color{#2196f3}{[\\text{a set}]}$",
+                "$S = \\color{#2196f3}{\\{x : x > 0\\}}$",
+            ),
+        ]);
+    });
+
+    test("a malformed \\cloze (missing second arg) is left alone", () => {
+        // No second {...} -> not a valid cloze -> no cards produced.
+        expect(expandMathClozes("$\\cloze{a}$")).toEqual([]);
+    });
+});

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -491,6 +491,16 @@ test("Test parsing of cloze cards", () => {
         }),
     ).toEqual([]);
 
+    // \cloze{answer}{hint} LaTeX macro (detected regardless of configured clozePatterns)
+    expect(parseT("$\\cloze{c^2}{}$ = a^2 + b^2", parserOptions)).toEqual([
+        [CardType.Cloze, "$\\cloze{c^2}{}$ = a^2 + b^2", 0, 0],
+    ]);
+    expect(parseT("$$\n\\cloze{a^2}{} + \\cloze{b^2}{} = c^2\n$$\n", parserOptions)).toEqual([
+        [CardType.Cloze, "$$\n\\cloze{a^2}{} + \\cloze{b^2}{} = c^2\n$$", 0, 2],
+    ]);
+    // \clozeXYZ must NOT be picked up (command boundary)
+    expect(parseT("$\\clozenot{a}{b}$", parserOptions)).toEqual([]);
+
     // custom cloze formats
     // Anki-like pattern
     //  Notice that the single line separators have to be different

--- a/tests/unit/scheduling/flashcard-review-sequencer.test.ts
+++ b/tests/unit/scheduling/flashcard-review-sequencer.test.ts
@@ -1379,3 +1379,45 @@ async function checkupdateClozeCurrentQuestionTextAndCards(
     expect(await c.file.read()).toEqual(expectedFileText);
     return c;
 }
+
+describe("\\cloze{answer}{hint} math cloze cards (end-to-end)", () => {
+    test("registers as a cloze card and places the SR comment after the $$ block", async () => {
+        const text = "#flashcards\n\n$$\n\\cloze{E}{} = mc^2\n$$\n";
+        const c: TestContext = TestContext.Create(
+            orderDueFirstSequential,
+            FlashcardReviewMode.Review,
+            DEFAULT_SETTINGS,
+            text,
+        );
+        await c.setSequencerDeckTreeFromOriginalText();
+
+        // Registered as one cloze card: front occludes the answer, back reveals it (both in $$).
+        expect(c.cardSequencer.currentDeck.getRepItemCount(RepItemState.AnyItem, false)).toEqual(1);
+        expect(c.reviewSequencer.currentCard.front).toBe(
+            "$$\n\\color{#2196f3}{[\\ldots]} = mc^2\n$$",
+        );
+        expect(c.reviewSequencer.currentCard.back).toBe("$$\n\\color{#2196f3}{E} = mc^2\n$$");
+
+        await c.reviewSequencer.processReview(ReviewResponse.Easy);
+        const out: string = c.file.content;
+
+        // The math block is preserved verbatim (nothing injected inside it) ...
+        expect(out).toContain("$$\n\\cloze{E}{} = mc^2\n$$");
+        // ... and the SR comment sits AFTER the closing $$, i.e. outside the math.
+        expect(out).toMatch(/\$\$\n<!--SR:!/);
+        expect(out.indexOf("<!--SR:")).toBeGreaterThan(out.lastIndexOf("$$"));
+    });
+
+    test("multiple \\cloze in one block become sibling cards", async () => {
+        const text = "#flashcards\n\n$$\n\\cloze{a^2}{} + \\cloze{b^2}{} = c^2\n$$\n";
+        const c: TestContext = TestContext.Create(
+            orderDueFirstSequential,
+            FlashcardReviewMode.Review,
+            DEFAULT_SETTINGS,
+            text,
+        );
+        await c.setSequencerDeckTreeFromOriginalText();
+
+        expect(c.cardSequencer.currentDeck.getRepItemCount(RepItemState.AnyItem, false)).toEqual(2);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a `\cloze{answer}{hint}` macro for cloze deletions inside LaTeX math (`$...$` and `$$...$$`).

Cloze deletions inside math were not well supported: `==` and `**` change the LaTeX rendering, and `{{...}}` collides with LaTeX's own use of braces (e.g. `\frac{{x}}{y}`, `e^{x^{2}}`). `\cloze` is a dedicated, collision-free token — nothing in ordinary LaTeX produces it, and it renders normally when reading a note.

Related to #1100 (cloze support in math); this takes the macro route rather than overloading `{{...}}`.

## How it works

- **Preview**: `\cloze` is registered once as a global MathJax macro (`\def\cloze#1#2{#1}`) that expands to the answer, so reading a note shows the full formula in Reading view and Live Preview.
- **Review**: the macro is parsed in the card-generation path using balanced-brace argument scanning, so nested braces, fractions, roots, and escaped braces (`\{ \}`) all parse correctly. Each `\cloze` becomes one sibling card — the target is occluded on the front (`[hint]` or `[…]`) and revealed/highlighted on the back, while the other clozes show their answer.

## Example

```
$$
\cloze{c^2}{} = \cloze{a^2 + b^2}{Pythagoras}
$$
```

Generates two sibling cards (e.g. card 1 front `[…] = a^2 + b^2`, back `c^2 = a^2 + b^2`).

## Notes

- `\cloze` is math-only and complements the existing `==` / `**` / `{{...}}` patterns; it needs no entry in Custom Cloze Patterns.
- Existing behaviour is untouched: a note without `\cloze` goes through clozecraft exactly as before.
- Minor documented caveat: a note already open when the plugin loads keeps its earlier render until its view is rebuilt (switch notes and back, or reopen). Notes opened afterwards are fine.

## Testing

- `pnpm validate` passes (381 tests).
- New unit tests for parsing/expansion (`math-cloze.test.ts`), parser detection, and an end-to-end test covering card registration and SR-comment placement (the comment lands after the `$$` block, never inside the math).
- Docs added under Flashcards → Cloze Cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
