### PR TITLE
feat: Enhance review notes sidebar

### DIFF
--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -33,8 +33,8 @@
             & > .tree-item-self::after {
                 margin-left: auto;
                 content: "";
-                width: 0.6rem;
-                height: 0.6rem;
+                width: var(--size-4-3);
+                height: var(--size-4-3);
                 border-radius: 50% 50%;
                 background: linear-gradient(90deg, var(--color-red) 40%, var(--color-green) 60%);
             }
@@ -52,8 +52,8 @@
         & > .tree-item-self::after {
             margin-left: auto;
             content: "";
-            width: 0.6rem;
-            height: 0.6rem;
+            width: var(--size-4-3);
+            height: var(--size-4-3);
             border-radius: 50% 50%;
             background: var(--color-red);
         }
@@ -70,8 +70,8 @@
             & > .tree-item-self::after {
                 margin-left: auto;
                 content: "";
-                width: 0.6rem;
-                height: 0.6rem;
+                width: var(--size-4-3);
+                height: var(--size-4-3);
                 border-radius: 50% 50%;
                 background: var(--color-green);
             }
@@ -87,8 +87,8 @@
         &.is-collapsed > .tree-item-self::after {
             margin-left: auto;
             content: "";
-            width: 0.6rem;
-            height: 0.6rem;
+            width: var(--size-4-3);
+            height: var(--size-4-3);
             border-radius: 50% 50%;
             background: var(--color-green);
         }
@@ -102,8 +102,8 @@
         &.is-collapsed > .tree-item-self::after {
             margin-left: auto;
             content: "";
-            width: 0.6rem;
-            height: 0.6rem;
+            width: var(--size-4-3);
+            height: var(--size-4-3);
             border-radius: 50% 50%;
             background: var(--color-red);
         }

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -16,10 +16,35 @@
         border-radius: var(--input-radius);
     }
 
+    .tree-item.sr-deck-item.is-collapsed > .tree-item-self::after {
+        margin-left: auto;
+        content: "●";
+    }
+    .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-due-today) > .tree-item-self::after {
+        margin-left: auto;
+        content: "●";
+        color: #2f9e44;
+    }
+    .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-overdue) > .tree-item-self::after {
+        margin-left: auto;
+        content: "●";
+        color: #e03131;
+    }
+
     .nav-file-title {
         display: flex;
         align-items: center;
         justify-content: space-between;
+
+        &.sr-note-due-today {
+            border-left: 4px solid #2f9e44;
+            border-radius: var(--input-radius);
+        }
+
+        &.sr-note-overdue {
+            border-left: 4px solid #e03131;
+            border-radius: var(--input-radius);
+        }
     }
 
     .nav-file-title-content {

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -16,18 +16,18 @@
         border-radius: var(--input-radius);
     }
 
-    .tree-item.sr-deck-item.is-collapsed > .tree-item-self::after {
-        margin-left: auto;
-        content: "●";
-    }
     .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-due-today) > .tree-item-self::after {
         margin-left: auto;
-        content: "●";
+        content: "";
+        width: 0.6rem;
+        height: 0.6rem;
         color: #2f9e44;
     }
     .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-overdue) > .tree-item-self::after {
         margin-left: auto;
-        content: "●";
+        content: "";
+        width: 0.6rem;
+        height: 0.6rem;
         color: #e03131;
     }
 
@@ -35,16 +35,106 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+    }
 
-        &.sr-note-due-today {
-            border-left: 4px solid #2f9e44;
-            border-radius: var(--input-radius);
-        }
+    /* Select folder which has descendant :
+      .sr-file--due-over AND (.sr-file--due-today OR .sr-file--new)
 
-        &.sr-note-overdue {
-            border-left: 4px solid #e03131;
-            border-radius: var(--input-radius);
+      Add red-green indicator
+    */
+    .sr-folder--deck.is-collapsed:has(.sr-file--due-over) {
+        &:has(.sr-file--due-today),
+        &:has(.sr-file--new) {
+            & > .tree-item-self::after {
+                margin-left: auto;
+                content: "";
+                width: 0.6rem;
+                height: 0.6rem;
+                border-radius: 50% 50%;
+                background: linear-gradient(
+                    120deg,
+                    rgba(224, 49, 49, 1) 29%,
+                    rgba(87, 199, 133, 1) 100%,
+                    rgba(47, 158, 68, 1) 100%
+                );
+            }
         }
+    }
+
+    /* Select folder which has descendant :
+      .sr-file--due-over AND (NOT .sr-file--due-today) AND (NOT sr-file--new)
+      
+      Add reddish indicator
+    */
+    .sr-folder--deck.is-collapsed:has(.sr-file--due-over):not(:has(.sr-file--due-today)):not(
+            :has(.sr-file--new)
+        ) {
+        & > .tree-item-self::after {
+            margin-left: auto;
+            color: #e03131;
+        }
+    }
+
+    /* Select folder which has descendant :
+      NOT .sr-file--due-over AND (.sr-file--due-today OR .sr-file--new)
+      
+      Add greenish indicator
+    */
+    .sr-folder--deck.is-collapsed:not(:has(.sr-file--due-over)) {
+        &:has(.sr-file--due-today),
+        &:has(.sr-file--new) {
+            & > .tree-item-self::after {
+                margin-left: auto;
+                color: #2f9e44;
+            }
+        }
+    }
+
+    /* Select 'New' and 'Today' folders
+      
+      Add greenish indicator
+    */
+    .sr-folder--schedule--new,
+    .sr-folder--schedule--due-today {
+        &.is-collapsed > .tree-item-self::after {
+            margin-left: auto;
+            content: "";
+            width: 0.6rem;
+            height: 0.6rem;
+            color: #2f9e44;
+        }
+    }
+
+    /* Select 'Overdue' folder
+      
+      Add reddish indicator
+    */
+    .sr-folder--schedule--due-over {
+        &.is-collapsed > .tree-item-self::after {
+            margin-left: auto;
+            content: "";
+            width: 0.6rem;
+            height: 0.6rem;
+            color: #e03131;
+        }
+    }
+
+    /* Select files which are either new or due-today
+        Add greenish left border
+     */
+    .sr-file--due-today,
+    .sr-file--new {
+        border-left: 4px solid #2f9e44;
+        border-radius: var(--input-radius);
+    }
+
+    /* Select files which are either over-due
+        Add reddish left border
+     */
+
+    .sr-file--due-over {
+        border-left: 4px solid #e03131;
+        border-radius: var(--input-radius);
     }
 
     .nav-file-title-content {

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -36,12 +36,7 @@
                 width: 0.6rem;
                 height: 0.6rem;
                 border-radius: 50% 50%;
-                background: linear-gradient(
-                    120deg,
-                    rgba(224, 49, 49, 1) 29%,
-                    rgba(87, 199, 133, 1) 100%,
-                    rgba(47, 158, 68, 1) 100%
-                );
+                background: linear-gradient(90deg, var(--color-red) 40%, var(--color-green) 60%);
             }
         }
     }
@@ -60,7 +55,7 @@
             width: 0.6rem;
             height: 0.6rem;
             border-radius: 50% 50%;
-            background: #e03131;
+            background: var(--color-red);
         }
     }
 
@@ -78,7 +73,7 @@
                 width: 0.6rem;
                 height: 0.6rem;
                 border-radius: 50% 50%;
-                background: #2f9e44;
+                background: var(--color-green);
             }
         }
     }
@@ -95,7 +90,7 @@
             width: 0.6rem;
             height: 0.6rem;
             border-radius: 50% 50%;
-            background: #2f9e44;
+            background: var(--color-green);
         }
     }
 
@@ -110,7 +105,7 @@
             width: 0.6rem;
             height: 0.6rem;
             border-radius: 50% 50%;
-            background: #e03131;
+            background: var(--color-red);
         }
     }
 
@@ -119,7 +114,7 @@
      */
     .sr-file--due-today,
     .sr-file--new {
-        border-left: var(--size-4-1) solid #2f9e44;
+        border-left: var(--size-4-1) solid var(--color-green);
     }
 
     /* Select files which are either over-due
@@ -127,7 +122,7 @@
      */
 
     .sr-file--due-over {
-        border-left: var(--size-4-1) solid #e03131;
+        border-left: var(--size-4-1) solid var(--color-red);
     }
 
     .nav-file-title-content {

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -16,21 +16,6 @@
         border-radius: var(--input-radius);
     }
 
-    .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-due-today) > .tree-item-self::after {
-        margin-left: auto;
-        content: "";
-        width: 0.6rem;
-        height: 0.6rem;
-        color: #2f9e44;
-    }
-    .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-overdue) > .tree-item-self::after {
-        margin-left: auto;
-        content: "";
-        width: 0.6rem;
-        height: 0.6rem;
-        color: #e03131;
-    }
-
     .nav-file-title {
         display: flex;
         align-items: center;

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -71,7 +71,11 @@
         ) {
         & > .tree-item-self::after {
             margin-left: auto;
-            color: #e03131;
+            content: "";
+            width: 0.6rem;
+            height: 0.6rem;
+            border-radius: 50% 50%;
+            background: #e03131;
         }
     }
 
@@ -85,7 +89,11 @@
         &:has(.sr-file--new) {
             & > .tree-item-self::after {
                 margin-left: auto;
-                color: #2f9e44;
+                content: "";
+                width: 0.6rem;
+                height: 0.6rem;
+                border-radius: 50% 50%;
+                background: #2f9e44;
             }
         }
     }
@@ -101,7 +109,8 @@
             content: "";
             width: 0.6rem;
             height: 0.6rem;
-            color: #2f9e44;
+            border-radius: 50% 50%;
+            background: #2f9e44;
         }
     }
 
@@ -115,7 +124,8 @@
             content: "";
             width: 0.6rem;
             height: 0.6rem;
-            color: #e03131;
+            border-radius: 50% 50%;
+            background: #e03131;
         }
     }
 

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -119,8 +119,7 @@
      */
     .sr-file--due-today,
     .sr-file--new {
-        border-left: 4px solid #2f9e44;
-        border-radius: var(--input-radius);
+        border-left: var(--size-4-1) solid #2f9e44;
     }
 
     /* Select files which are either over-due
@@ -128,8 +127,7 @@
      */
 
     .sr-file--due-over {
-        border-left: 4px solid #e03131;
-        border-radius: var(--input-radius);
+        border-left: var(--size-4-1) solid #e03131;
     }
 
     .nav-file-title-content {

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.css
@@ -37,7 +37,7 @@
         justify-content: space-between;
     }
 
-    /* Select folder which has descendant :
+    /* Select deck folders which has descendant :
       .sr-file--due-over AND (.sr-file--due-today OR .sr-file--new)
 
       Add red-green indicator
@@ -61,7 +61,7 @@
         }
     }
 
-    /* Select folder which has descendant :
+    /* Select deck folders which has descendant :
       .sr-file--due-over AND (NOT .sr-file--due-today) AND (NOT sr-file--new)
       
       Add reddish indicator
@@ -79,7 +79,7 @@
         }
     }
 
-    /* Select folder which has descendant :
+    /* Select deck folders which has descendant :
       NOT .sr-file--due-over AND (.sr-file--due-today OR .sr-file--new)
       
       Add greenish indicator

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
@@ -188,8 +188,7 @@ export class ReviewQueueListView extends ItemView {
         const now: number = Date.now();
         let currUnix = -1;
         let scheduleFolderEl: HTMLElement | null = null,
-            folderTitle = "",
-            folderClassName = "";
+            folderTitle = "";
         const maxDaysToRender: number = this.settings.maxNDaysNotesReviewQueue;
 
         for (const sNote of deck.scheduledNotes) {
@@ -202,13 +201,10 @@ export class ReviewQueueListView extends ItemView {
 
                 if (nDays === -1) {
                     folderTitle = t("YESTERDAY");
-                    folderClassName = "sr-folder--due-over";
                 } else if (nDays === 0) {
                     folderTitle = t("TODAY");
-                    folderClassName = "sr-folder--due-today";
                 } else if (nDays === 1) {
                     folderTitle = t("TOMORROW");
-                    folderClassName = "sr-folder--due-none";
                 } else {
                     folderTitle = formatDateWithMoment(
                         sNote.dueUnix,
@@ -289,7 +285,9 @@ export class ReviewQueueListView extends ItemView {
         },
     ): HTMLElement {
         const folderEl: HTMLDivElement = parentEl.createDiv("tree-item nav-folder");
-        classes?.treeItem && folderEl.classList.add(...classes?.treeItem);
+        if (classes?.treeItem) {
+            folderEl.classList.add(...classes.treeItem);
+        }
         const folderTitleEl: HTMLDivElement = folderEl.createDiv("tree-item-self nav-folder-title");
         folderTitleEl.classList.add("is-clickable");
         const childrenEl: HTMLDivElement = folderEl.createDiv(
@@ -357,7 +355,9 @@ export class ReviewQueueListView extends ItemView {
         if (fileElActive) {
             navFileTitle.addClass("is-active");
         }
-        classes?.treeItemSelf && navFileTitle.classList.add(...classes?.treeItemSelf);
+        if (classes?.treeItemSelf) {
+            navFileTitle.classList.add(...classes.treeItemSelf);
+        }
         const navFileTitleInner: HTMLElement = navFileTitle.createDiv(
             "tree-item-inner nav-file-title-content",
         );

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
@@ -118,7 +118,7 @@ export class ReviewQueueListView extends ItemView {
         deck: NoteReviewDeck,
         deckCollapsed: boolean,
     ) {
-        const folderEl: HTMLElement = this.createFolder(
+        const deckFolderEl: HTMLElement = this.createFolder(
             parentEl,
             deckKey,
             deckCollapsed,
@@ -127,10 +127,7 @@ export class ReviewQueueListView extends ItemView {
             {
                 treeItem: ["sr-folder--deck"],
             },
-        );
-        const deckFolderEl = folderEl.getElementsByClassName(
-            "tree-item-children nav-folder-children",
-        )[0] as HTMLElement;
+        ).getElementsByClassName("tree-item-children nav-folder-children")[0] as HTMLElement;
 
         if (deck.newNotes.length > 0) {
             this.createNewNotesFolder(deckFolderEl, deck, deckCollapsed);

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
@@ -249,7 +249,7 @@ export class ReviewQueueListView extends ItemView {
         hidden: boolean,
         deck: NoteReviewDeck,
     ): HTMLElement {
-        const folderEl: HTMLDivElement = parentEl.createDiv("tree-item nav-folder sr-folder");
+        const folderEl: HTMLDivElement = parentEl.createDiv("tree-item nav-folder");
         const folderTitleEl: HTMLDivElement = folderEl.createDiv("tree-item-self nav-folder-title");
         folderTitleEl.classList.add("is-clickable");
         const childrenEl: HTMLDivElement = folderEl.createDiv(

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
@@ -15,7 +15,7 @@ import { formatDateWithMoment } from "src/utils/dates";
 
 export const REVIEW_QUEUE_VIEW_TYPE = "review-queue-list-view";
 
-type NoteDueStatus = "overdue" | "due-today";
+type DueStatus = "DUE_OVER" | "DUE_TODAY" | "DUE_NONE";
 
 export class ReviewQueueListView extends ItemView {
     private get noteReviewQueue(): NoteReviewQueue {
@@ -124,8 +124,10 @@ export class ReviewQueueListView extends ItemView {
             deckCollapsed,
             false,
             deck,
+            {
+                treeItem: ["sr-folder--deck"],
+            },
         );
-        folderEl.classList.add("sr-deck-item");
         const deckFolderEl = folderEl.getElementsByClassName(
             "tree-item-children nav-folder-children",
         )[0] as HTMLElement;
@@ -150,8 +152,10 @@ export class ReviewQueueListView extends ItemView {
             !deck.activeFolders.has(t("NEW")),
             deckCollapsed,
             deck,
+            {
+                treeItem: ["sr-folder--schedule--new"],
+            },
         );
-        newNotesFolderEl.classList.add("sr-due-status-item");
 
         for (const newFile of deck.newNotes) {
             const fileIsOpen =
@@ -168,7 +172,9 @@ export class ReviewQueueListView extends ItemView {
                 fileIsOpen,
                 !deck.activeFolders.has(t("NEW")),
                 deck,
-                "due-today",
+                {
+                    treeItemSelf: ["sr-file--new"],
+                },
             );
         }
     }
@@ -182,7 +188,8 @@ export class ReviewQueueListView extends ItemView {
         const now: number = Date.now();
         let currUnix = -1;
         let scheduleFolderEl: HTMLElement | null = null,
-            folderTitle = "";
+            folderTitle = "",
+            folderClassName = "";
         const maxDaysToRender: number = this.settings.maxNDaysNotesReviewQueue;
 
         for (const sNote of deck.scheduledNotes) {
@@ -195,15 +202,31 @@ export class ReviewQueueListView extends ItemView {
 
                 if (nDays === -1) {
                     folderTitle = t("YESTERDAY");
+                    folderClassName = "sr-folder--due-over";
                 } else if (nDays === 0) {
                     folderTitle = t("TODAY");
+                    folderClassName = "sr-folder--due-today";
                 } else if (nDays === 1) {
                     folderTitle = t("TOMORROW");
+                    folderClassName = "sr-folder--due-none";
                 } else {
                     folderTitle = formatDateWithMoment(
                         sNote.dueUnix,
                         this.settings.preferredDateFormatForNoteReviewQueue,
                     );
+                }
+
+                let dueStatusClassName;
+                switch (this.getDueStatus(nDays)) {
+                    case "DUE_TODAY":
+                        dueStatusClassName = "sr-folder--schedule--due-today";
+                        break;
+                    case "DUE_OVER":
+                        dueStatusClassName = "sr-folder--schedule--due-over";
+                        break;
+                    case "DUE_NONE":
+                        dueStatusClassName = "sr-folder--schedule--due-none";
+                        break;
                 }
 
                 scheduleFolderEl = this.createFolder(
@@ -212,8 +235,8 @@ export class ReviewQueueListView extends ItemView {
                     !deck.activeFolders.has(folderTitle),
                     deckCollapsed,
                     deck,
+                    { treeItem: ["sr-folder--schedule", dueStatusClassName] },
                 );
-                scheduleFolderEl.classList.add("sr-due-status-item");
                 currUnix = sNote.dueUnix;
             }
 
@@ -227,8 +250,19 @@ export class ReviewQueueListView extends ItemView {
             }
 
             if (scheduleFolderEl) {
-                const dueStatus: NoteDueStatus | undefined =
-                    nDays < 0 ? "overdue" : nDays === 0 ? "due-today" : undefined;
+                let fileDueStatusClassName;
+
+                switch (this.getDueStatus(nDays)) {
+                    case "DUE_TODAY":
+                        fileDueStatusClassName = "sr-file--due-today";
+                        break;
+                    case "DUE_OVER":
+                        fileDueStatusClassName = "sr-file--due-over";
+                        break;
+                    case "DUE_NONE":
+                        fileDueStatusClassName = "sr-file--due-none";
+                        break;
+                }
 
                 this.createFile(
                     scheduleFolderEl,
@@ -236,7 +270,9 @@ export class ReviewQueueListView extends ItemView {
                     fileIsOpen,
                     !deck.activeFolders.has(folderTitle),
                     deck,
-                    dueStatus,
+                    {
+                        treeItemSelf: [fileDueStatusClassName],
+                    },
                 );
             }
         }
@@ -248,8 +284,12 @@ export class ReviewQueueListView extends ItemView {
         collapsed: boolean,
         hidden: boolean,
         deck: NoteReviewDeck,
+        classes?: {
+            treeItem?: string[];
+        },
     ): HTMLElement {
         const folderEl: HTMLDivElement = parentEl.createDiv("tree-item nav-folder");
+        classes?.treeItem && folderEl.classList.add(...classes?.treeItem);
         const folderTitleEl: HTMLDivElement = folderEl.createDiv("tree-item-self nav-folder-title");
         folderTitleEl.classList.add("is-clickable");
         const childrenEl: HTMLDivElement = folderEl.createDiv(
@@ -297,7 +337,9 @@ export class ReviewQueueListView extends ItemView {
         fileElActive: boolean,
         hidden: boolean,
         deck: NoteReviewDeck,
-        dueStatus?: NoteDueStatus,
+        classes?: {
+            treeItemSelf: string[];
+        },
     ): void {
         const childrenEl: HTMLElement = folderEl.getElementsByClassName(
             "tree-item-children nav-folder-children",
@@ -315,13 +357,7 @@ export class ReviewQueueListView extends ItemView {
         if (fileElActive) {
             navFileTitle.addClass("is-active");
         }
-
-        if (dueStatus === "overdue") {
-            navFileTitle.addClass("sr-note-overdue");
-        } else if (dueStatus === "due-today") {
-            navFileTitle.addClass("sr-note-due-today");
-        }
-
+        classes?.treeItemSelf && navFileTitle.classList.add(...classes?.treeItemSelf);
         const navFileTitleInner: HTMLElement = navFileTitle.createDiv(
             "tree-item-inner nav-file-title-content",
         );
@@ -433,5 +469,9 @@ export class ReviewQueueListView extends ItemView {
             folderEl.removeClass("is-collapsed");
             if (childEl) childEl.classList.remove("is-collapsed");
         }
+    }
+
+    private getDueStatus(nDays: number): DueStatus {
+        return nDays < 0 ? "DUE_OVER" : nDays === 0 ? "DUE_TODAY" : "DUE_NONE";
     }
 }

--- a/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
+++ b/src/ui/obsidian-ui-components/item-views/review-queue-list-view.tsx
@@ -15,6 +15,8 @@ import { formatDateWithMoment } from "src/utils/dates";
 
 export const REVIEW_QUEUE_VIEW_TYPE = "review-queue-list-view";
 
+type NoteDueStatus = "overdue" | "due-today";
+
 export class ReviewQueueListView extends ItemView {
     private get noteReviewQueue(): NoteReviewQueue {
         return this.nextNoteReviewHandler.noteReviewQueue;
@@ -116,13 +118,17 @@ export class ReviewQueueListView extends ItemView {
         deck: NoteReviewDeck,
         deckCollapsed: boolean,
     ) {
-        const deckFolderEl: HTMLElement = this.createFolder(
+        const folderEl: HTMLElement = this.createFolder(
             parentEl,
             deckKey,
             deckCollapsed,
             false,
             deck,
-        ).getElementsByClassName("tree-item-children nav-folder-children")[0] as HTMLElement;
+        );
+        folderEl.classList.add("sr-deck-item");
+        const deckFolderEl = folderEl.getElementsByClassName(
+            "tree-item-children nav-folder-children",
+        )[0] as HTMLElement;
 
         if (deck.newNotes.length > 0) {
             this.createNewNotesFolder(deckFolderEl, deck, deckCollapsed);
@@ -145,6 +151,7 @@ export class ReviewQueueListView extends ItemView {
             deckCollapsed,
             deck,
         );
+        newNotesFolderEl.classList.add("sr-due-status-item");
 
         for (const newFile of deck.newNotes) {
             const fileIsOpen =
@@ -161,6 +168,7 @@ export class ReviewQueueListView extends ItemView {
                 fileIsOpen,
                 !deck.activeFolders.has(t("NEW")),
                 deck,
+                "due-today",
             );
         }
     }
@@ -178,9 +186,9 @@ export class ReviewQueueListView extends ItemView {
         const maxDaysToRender: number = this.settings.maxNDaysNotesReviewQueue;
 
         for (const sNote of deck.scheduledNotes) {
-            if (sNote.dueUnix !== currUnix) {
-                const nDays: number = Math.ceil((sNote.dueUnix - now) / TICKS_PER_DAY);
+            const nDays: number = Math.ceil((sNote.dueUnix - now) / TICKS_PER_DAY);
 
+            if (sNote.dueUnix !== currUnix) {
                 if (nDays > maxDaysToRender) {
                     break;
                 }
@@ -205,6 +213,7 @@ export class ReviewQueueListView extends ItemView {
                     deckCollapsed,
                     deck,
                 );
+                scheduleFolderEl.classList.add("sr-due-status-item");
                 currUnix = sNote.dueUnix;
             }
 
@@ -218,12 +227,16 @@ export class ReviewQueueListView extends ItemView {
             }
 
             if (scheduleFolderEl) {
+                const dueStatus: NoteDueStatus | undefined =
+                    nDays < 0 ? "overdue" : nDays === 0 ? "due-today" : undefined;
+
                 this.createFile(
                     scheduleFolderEl,
                     sNote.note.tfile,
                     fileIsOpen,
                     !deck.activeFolders.has(folderTitle),
                     deck,
+                    dueStatus,
                 );
             }
         }
@@ -236,7 +249,7 @@ export class ReviewQueueListView extends ItemView {
         hidden: boolean,
         deck: NoteReviewDeck,
     ): HTMLElement {
-        const folderEl: HTMLDivElement = parentEl.createDiv("tree-item nav-folder");
+        const folderEl: HTMLDivElement = parentEl.createDiv("tree-item nav-folder sr-folder");
         const folderTitleEl: HTMLDivElement = folderEl.createDiv("tree-item-self nav-folder-title");
         folderTitleEl.classList.add("is-clickable");
         const childrenEl: HTMLDivElement = folderEl.createDiv(
@@ -284,6 +297,7 @@ export class ReviewQueueListView extends ItemView {
         fileElActive: boolean,
         hidden: boolean,
         deck: NoteReviewDeck,
+        dueStatus?: NoteDueStatus,
     ): void {
         const childrenEl: HTMLElement = folderEl.getElementsByClassName(
             "tree-item-children nav-folder-children",
@@ -300,6 +314,12 @@ export class ReviewQueueListView extends ItemView {
 
         if (fileElActive) {
             navFileTitle.addClass("is-active");
+        }
+
+        if (dueStatus === "overdue") {
+            navFileTitle.addClass("sr-note-overdue");
+        } else if (dueStatus === "due-today") {
+            navFileTitle.addClass("sr-note-due-today");
         }
 
         const navFileTitleInner: HTMLElement = navFileTitle.createDiv(

--- a/styles.css
+++ b/styles.css
@@ -1142,22 +1142,6 @@ th.gridjs-th:last-child {
     background-color: var(--background-modifier-hover);
     border-radius: var(--input-radius);
   }
-  .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-due-today)
-    > .tree-item-self::after {
-    margin-left: auto;
-    content: "";
-    width: 0.6rem;
-    height: 0.6rem;
-    color: #2f9e44;
-  }
-  .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-overdue)
-    > .tree-item-self::after {
-    margin-left: auto;
-    content: "";
-    width: 0.6rem;
-    height: 0.6rem;
-    color: #e03131;
-  }
   .nav-file-title {
     display: flex;
     align-items: center;
@@ -1173,10 +1157,9 @@ th.gridjs-th:last-child {
         height: 0.6rem;
         border-radius: 50% 50%;
         background: linear-gradient(
-          120deg,
-          rgba(224, 49, 49, 1) 29%,
-          rgba(87, 199, 133, 1) 100%,
-          rgba(47, 158, 68, 1) 100%
+          90deg,
+          var(--color-red) 40%,
+          var(--color-green) 60%
         );
       }
     }
@@ -1190,7 +1173,7 @@ th.gridjs-th:last-child {
       width: 0.6rem;
       height: 0.6rem;
       border-radius: 50% 50%;
-      background: #e03131;
+      background: var(--color-red);
     }
   }
   .sr-folder--deck.is-collapsed:not(:has(.sr-file--due-over)) {
@@ -1202,7 +1185,7 @@ th.gridjs-th:last-child {
         width: 0.6rem;
         height: 0.6rem;
         border-radius: 50% 50%;
-        background: #2f9e44;
+        background: var(--color-green);
       }
     }
   }
@@ -1214,7 +1197,7 @@ th.gridjs-th:last-child {
       width: 0.6rem;
       height: 0.6rem;
       border-radius: 50% 50%;
-      background: #2f9e44;
+      background: var(--color-green);
     }
   }
   .sr-folder--schedule--due-over {
@@ -1224,17 +1207,15 @@ th.gridjs-th:last-child {
       width: 0.6rem;
       height: 0.6rem;
       border-radius: 50% 50%;
-      background: #e03131;
+      background: var(--color-red);
     }
   }
   .sr-file--due-today,
   .sr-file--new {
-    border-left: 4px solid #2f9e44;
-    border-radius: var(--input-radius);
+    border-left: var(--size-4-1) solid var(--color-green);
   }
   .sr-file--due-over {
-    border-left: 4px solid #e03131;
-    border-radius: var(--input-radius);
+    border-left: var(--size-4-1) solid var(--color-red);
   }
   .nav-file-title-content {
     display: flex;

--- a/styles.css
+++ b/styles.css
@@ -1142,10 +1142,34 @@ th.gridjs-th:last-child {
     background-color: var(--background-modifier-hover);
     border-radius: var(--input-radius);
   }
+  .tree-item.sr-deck-item.is-collapsed > .tree-item-self::after {
+    margin-left: auto;
+    content: "\25cf";
+  }
+  .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-due-today)
+    > .tree-item-self::after {
+    margin-left: auto;
+    content: "\25cf";
+    color: #2f9e44;
+  }
+  .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-overdue)
+    > .tree-item-self::after {
+    margin-left: auto;
+    content: "\25cf";
+    color: #e03131;
+  }
   .nav-file-title {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    &.sr-note-due-today {
+      border-left: 4px solid #2f9e44;
+      border-radius: var(--input-radius);
+    }
+    &.sr-note-overdue {
+      border-left: 4px solid #e03131;
+      border-radius: var(--input-radius);
+    }
   }
   .nav-file-title-content {
     display: flex;

--- a/styles.css
+++ b/styles.css
@@ -1153,8 +1153,8 @@ th.gridjs-th:last-child {
       & > .tree-item-self::after {
         margin-left: auto;
         content: "";
-        width: 0.6rem;
-        height: 0.6rem;
+        width: var(--size-4-3);
+        height: var(--size-4-3);
         border-radius: 50% 50%;
         background: linear-gradient(
           90deg,
@@ -1170,8 +1170,8 @@ th.gridjs-th:last-child {
     & > .tree-item-self::after {
       margin-left: auto;
       content: "";
-      width: 0.6rem;
-      height: 0.6rem;
+      width: var(--size-4-3);
+      height: var(--size-4-3);
       border-radius: 50% 50%;
       background: var(--color-red);
     }
@@ -1182,8 +1182,8 @@ th.gridjs-th:last-child {
       & > .tree-item-self::after {
         margin-left: auto;
         content: "";
-        width: 0.6rem;
-        height: 0.6rem;
+        width: var(--size-4-3);
+        height: var(--size-4-3);
         border-radius: 50% 50%;
         background: var(--color-green);
       }
@@ -1194,8 +1194,8 @@ th.gridjs-th:last-child {
     &.is-collapsed > .tree-item-self::after {
       margin-left: auto;
       content: "";
-      width: 0.6rem;
-      height: 0.6rem;
+      width: var(--size-4-3);
+      height: var(--size-4-3);
       border-radius: 50% 50%;
       background: var(--color-green);
     }
@@ -1204,8 +1204,8 @@ th.gridjs-th:last-child {
     &.is-collapsed > .tree-item-self::after {
       margin-left: auto;
       content: "";
-      width: 0.6rem;
-      height: 0.6rem;
+      width: var(--size-4-3);
+      height: var(--size-4-3);
       border-radius: 50% 50%;
       background: var(--color-red);
     }

--- a/styles.css
+++ b/styles.css
@@ -1142,34 +1142,99 @@ th.gridjs-th:last-child {
     background-color: var(--background-modifier-hover);
     border-radius: var(--input-radius);
   }
-  .tree-item.sr-deck-item.is-collapsed > .tree-item-self::after {
-    margin-left: auto;
-    content: "\25cf";
-  }
   .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-due-today)
     > .tree-item-self::after {
     margin-left: auto;
-    content: "\25cf";
+    content: "";
+    width: 0.6rem;
+    height: 0.6rem;
     color: #2f9e44;
   }
   .tree-item.sr-due-status-item.is-collapsed:has(.sr-note-overdue)
     > .tree-item-self::after {
     margin-left: auto;
-    content: "\25cf";
+    content: "";
+    width: 0.6rem;
+    height: 0.6rem;
     color: #e03131;
   }
   .nav-file-title {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    &.sr-note-due-today {
-      border-left: 4px solid #2f9e44;
-      border-radius: var(--input-radius);
+  }
+  .sr-folder--deck.is-collapsed:has(.sr-file--due-over) {
+    &:has(.sr-file--due-today),
+    &:has(.sr-file--new) {
+      & > .tree-item-self::after {
+        margin-left: auto;
+        content: "";
+        width: 0.6rem;
+        height: 0.6rem;
+        border-radius: 50% 50%;
+        background: linear-gradient(
+          120deg,
+          rgba(224, 49, 49, 1) 29%,
+          rgba(87, 199, 133, 1) 100%,
+          rgba(47, 158, 68, 1) 100%
+        );
+      }
     }
-    &.sr-note-overdue {
-      border-left: 4px solid #e03131;
-      border-radius: var(--input-radius);
+  }
+  .sr-folder--deck.is-collapsed:has(.sr-file--due-over):not(
+      :has(.sr-file--due-today)
+    ):not(:has(.sr-file--new)) {
+    & > .tree-item-self::after {
+      margin-left: auto;
+      content: "";
+      width: 0.6rem;
+      height: 0.6rem;
+      border-radius: 50% 50%;
+      background: #e03131;
     }
+  }
+  .sr-folder--deck.is-collapsed:not(:has(.sr-file--due-over)) {
+    &:has(.sr-file--due-today),
+    &:has(.sr-file--new) {
+      & > .tree-item-self::after {
+        margin-left: auto;
+        content: "";
+        width: 0.6rem;
+        height: 0.6rem;
+        border-radius: 50% 50%;
+        background: #2f9e44;
+      }
+    }
+  }
+  .sr-folder--schedule--new,
+  .sr-folder--schedule--due-today {
+    &.is-collapsed > .tree-item-self::after {
+      margin-left: auto;
+      content: "";
+      width: 0.6rem;
+      height: 0.6rem;
+      border-radius: 50% 50%;
+      background: #2f9e44;
+    }
+  }
+  .sr-folder--schedule--due-over {
+    &.is-collapsed > .tree-item-self::after {
+      margin-left: auto;
+      content: "";
+      width: 0.6rem;
+      height: 0.6rem;
+      border-radius: 50% 50%;
+      background: #e03131;
+    }
+  }
+  .sr-file--due-today,
+  .sr-file--new {
+    border-left: 4px solid #2f9e44;
+    border-radius: var(--input-radius);
+  }
+  .sr-file--due-over {
+    border-left: 4px solid #e03131;
+    border-radius: var(--input-radius);
   }
   .nav-file-title-content {
     display: flex;


### PR DESCRIPTION
## Summary
Improves the Review Sidebar by adding visual indicators. 


## Problem

* Large deck hierarchies created significant file and folder clutter.
* Identifying overdue, due-today, and not-due notes required expanding folders and checking dates manually.

## Action

1. Added folder indicators based on the highest-priority note in the deck:

🔴 Red: Deck contains overdue notes
🟢 Green: Deck contains due-today notes (and no overdue notes)
🔵 Blue: Deck contains only new notes

If a deck contains mixed type of notes, the indicator reflects the highest-priority status:  
🔴 Overdue > 🟢 Due today > 🔵 New

2. Added left borders on files:

  🔴 Red: Overdue
  🟢 Green: Due today files
  🔵 Blue : New files

## Impact

* Provides clear visual cues for new, overdue, due-today, and mixed notes.
* Makes navigating large, cluttered review trees significantly easier.

## Changes Overview
1. Based on due-status, add appropriate classes to 'files' and 'folders'.
2. Applied styling by targeting these classes to render indicators and borders.

## Testing
1. `pnpm test` -> passes all tests
2. `pnpm lint` -> No errors
3. Tested on desktop / mobile / varying size devices.


## Videos and Screenshots

### Desktop mode

https://github.com/user-attachments/assets/6d81c39e-6519-4e84-8fd3-a4038437633f

### Mobile

<img width="721" height="731" alt="Screenshot 2026-07-07 at 3 51 09 PM" src="https://github.com/user-attachments/assets/29492846-8f16-4d5f-9109-79e71b78845a" />
