### PR TITLE
feat: Add interactive Multiple Choice Question support

### DIFF
--- a/docs/docs/en/flashcards/q-and-a-cards.md
+++ b/docs/docs/en/flashcards/q-and-a-cards.md
@@ -166,3 +166,37 @@ To include blank lines, see the section below.
 
 These two cards are considered sibling cards. See [sibling cards](flashcards-overview.md#sibling-cards) regarding the
 [Bury sibling cards until the next day](../user-options.md#flashcard-review) scheduling option.
+
+---
+
+## Multiple Choice Questions
+
+You can create interactive Multiple Choice Questions (MCQ) by combining the Multi-line format with standard Markdown checklists.
+Simply add a checklist on the front side of the card, marking the correct answer(s) with `[x]`.
+
+```markdown
+What is the capital of France?
+- [ ] London
+- [x] Paris
+- [ ] Berlin
+?
+Paris is the capital of France.
+```
+
+!!! note "Displayed when reviewed"
+
+    <div class="grid" markdown>
+
+    !!! tip "Card Front"
+
+        What is the capital of France?<br/><br/>
+        🔘 London<br/>
+        🔘 Paris<br/>
+        🔘 Berlin<br/>
+
+    !!! tip "Card Back"
+
+        The correct option (`Paris`) is highlighted in green. If you selected a wrong option, it will be highlighted in red.<br/><br/>
+        Paris is the capital of France.
+
+    </div>

--- a/src/ui/obsidian-ui-components/content-container/card-container/card-container.css
+++ b/src/ui/obsidian-ui-components/content-container/card-container/card-container.css
@@ -35,6 +35,41 @@
     & .sr-content .cloze-input {
         height: 1.4rem;
     }
+
+    & .sr-content .sr-mcq-option {
+        cursor: pointer;
+        padding: 8px 12px;
+        margin: 6px 0;
+        border: 1px solid var(--background-modifier-border);
+        border-radius: 6px;
+        background-color: var(--background-primary-alt);
+        transition: all 0.2s;
+        list-style: none;
+        text-decoration: none !important;
+        color: var(--text-normal) !important;
+    }
+    
+    & .sr-content .sr-mcq-option:hover {
+        background-color: var(--background-modifier-hover);
+        border-color: var(--interactive-accent);
+    }
+    
+    & .sr-content .sr-mcq-selected {
+        background-color: var(--background-modifier-active);
+        border-color: var(--interactive-accent);
+    }
+
+    & .sr-content .sr-mcq-correct {
+        background-color: var(--text-success, var(--color-green, #4caf50));
+        color: white !important;
+        border-color: var(--text-success, var(--color-green, #4caf50));
+    }
+
+    & .sr-content .sr-mcq-wrong {
+        background-color: var(--text-error, var(--color-red, #f44336));
+        color: white !important;
+        border-color: var(--text-error, var(--color-red, #f44336));
+    }
 }
 
 @media only screen and (orientation: landscape) {

--- a/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
@@ -41,6 +41,7 @@ export class CardContainer {
 
     private clozeInputs: NodeListOf<HTMLInputElement> | null = null;
     private clozeAnswers: NodeListOf<Element> | null = null;
+    private selectedMcqIndex: number | null = null;
 
     private processReviewHandler: (response: ReviewResponse) => Promise<void>;
     private skipCardHandler: () => void;
@@ -163,6 +164,7 @@ export class CardContainer {
     }
 
     public async drawCardFront(sessionData: SessionData, settings: SRSettings) {
+        this.selectedMcqIndex = null;
         this.toolbar.setResetButtonDisabled(true);
         // Update current deck info
         this.cardState = sessionData.cardData.currentCardState;
@@ -221,6 +223,35 @@ export class CardContainer {
         );
         // Set scroll position back to top
         this.content.scrollTop = 0;
+
+        // Process MCQ (Multiple Choice Questions) checkboxes
+        const listItems = this.content.findAll("li.task-list-item");
+        listItems.forEach((li, index) => {
+            li.addClass("sr-mcq-option");
+            
+            const checkbox = li.querySelector("input[type='checkbox']") as HTMLInputElement | null;
+            if (checkbox) {
+                checkbox.style.display = "none";
+                
+                if (this.cardState === CardState.Back) {
+                    if (checkbox.checked) {
+                        li.addClass("sr-mcq-correct");
+                    } else if (this.selectedMcqIndex === index) {
+                        li.addClass("sr-mcq-wrong");
+                    }
+                }
+            }
+
+            if (this.cardState === CardState.Front) {
+                li.addEventListener("click", (e: Event) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this.selectedMcqIndex = index;
+                    li.addClass("sr-mcq-selected");
+                    this.showAnswerHandler();
+                });
+            }
+        });
     }
 
     public drawPendingState(nextPendingDueUnix: number): void {

--- a/styles.css
+++ b/styles.css
@@ -164,6 +164,36 @@
   & .sr-content .cloze-input {
     height: 1.4rem;
   }
+  & .sr-content .sr-mcq-option {
+    cursor: pointer;
+    padding: 8px 12px;
+    margin: 6px 0;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 6px;
+    background-color: var(--background-primary-alt);
+    transition: all 0.2s;
+    list-style: none;
+    text-decoration: none !important;
+    color: var(--text-normal) !important;
+  }
+  & .sr-content .sr-mcq-option:hover {
+    background-color: var(--background-modifier-hover);
+    border-color: var(--interactive-accent);
+  }
+  & .sr-content .sr-mcq-selected {
+    background-color: var(--background-modifier-active);
+    border-color: var(--interactive-accent);
+  }
+  & .sr-content .sr-mcq-correct {
+    background-color: var(--text-success, var(--color-green, #4caf50));
+    color: white !important;
+    border-color: var(--text-success, var(--color-green, #4caf50));
+  }
+  & .sr-content .sr-mcq-wrong {
+    background-color: var(--text-error, var(--color-red, #f44336));
+    color: white !important;
+    border-color: var(--text-error, var(--color-red, #f44336));
+  }
 }
 @media only screen and (orientation: landscape) {
   .is-phone .sr-card-container {


### PR DESCRIPTION
Native support for interactive Multiple Choice Questions.
Users can now use standard markdown checklists on the front of a card to create clickable MCQ options.

Simply use a multi-line separator (`?` or `??`) and place a checklist on the front side, marking the correct answer(s) with `[x]`.


This is a file i've used to test it out.
[MCQ-Test-Deck.md](https://github.com/user-attachments/files/29421580/MCQ-Test-Deck.md)


And this is a show case of what i've been using. I think it's very easy to use, also helps me play more with cards.

https://github.com/user-attachments/assets/a143b924-f260-4122-809a-1a68eab4e267




   
I've made sure the implementation is lightweight and purely CSS/UI driven so it doesn't break any existing scheduling logic. Let me know if you need any changes ( probably yes ahah) !
