### PR TITLE
fix: refresh flashcard UI immediately after edit Save

### DIFF
--- a/src/scheduling/flashcard-review-sequencer.ts
+++ b/src/scheduling/flashcard-review-sequencer.ts
@@ -440,16 +440,24 @@ export class FlashcardReviewSequencer implements IFlashcardReviewSequencer {
 
         await this.currentQuestion.writeQuestion(this.settings);
 
-        if (cardFrontBackList.length !== question.cards.length) {
-            console.warn("SR: Cards count does not match question text. Skipping redraw.");
-            new Notice("Cards count does not match cards from question text. Skipping redraw.");
-            return;
-        }
-        question.cards.forEach((card, i) => {
+        // Always refresh in-memory faces for the overlapping cards so the review UI can redraw
+        // after Save. When the number of generated cards changes (e.g. cloze deletions), we
+        // still update as many as possible and notify the user that sibling count changed.
+        const updateCount = Math.min(cardFrontBackList.length, question.cards.length);
+        for (let i = 0; i < updateCount; i++) {
             const { front, back } = cardFrontBackList[i];
-            card.front = front;
-            card.back = back;
-        });
+            question.cards[i].front = front;
+            question.cards[i].back = back;
+        }
+
+        if (cardFrontBackList.length !== question.cards.length) {
+            console.warn(
+                "SR: Cards count does not match question text. Updated overlapping cards only.",
+            );
+            new Notice(
+                "Card count changed after edit. Updated current card text; restart review to fully re-parse siblings.",
+            );
+        }
     }
 
     async deleteCurrentCardFromNote(): Promise<void> {

--- a/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
@@ -206,6 +206,11 @@ export class CardContainer {
         // Create context section
         this.drawCardContext(sessionData, settings);
 
+        const currentCard = sessionData.cardData.currentCard;
+        if (currentCard === null) {
+            return;
+        }
+
         // Build card content
         const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
             this.app,
@@ -214,7 +219,7 @@ export class CardContainer {
         );
 
         await wrapper.renderMarkdownWrapper(
-            sessionData.cardData.currentCard.front.trimStart(),
+            currentCard.front.trimStart(),
             this.content,
             sessionData.currentQuestion.questionText.textDirection,
             // sessionData.cardData.currentCardState
@@ -358,13 +363,18 @@ export class CardContainer {
             this.drawCardContext(sessionData, settings);
         }
 
+        const currentCard = sessionData.cardData.currentCard;
+        if (currentCard === null) {
+            return;
+        }
+
         const wrapper: RenderMarkdownWrapper = new RenderMarkdownWrapper(
             this.app,
             this.plugin,
             sessionData.currentNote.filePath,
         );
         await wrapper.renderMarkdownWrapper(
-            sessionData.cardData.currentCard.back,
+            currentCard.back,
             this.content,
             sessionData.currentQuestion.questionText.textDirection,
             // sessionData.cardData.currentCardState,

--- a/src/ui/obsidian-ui-components/content-container/card-container/toolbar/toolbar.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/toolbar/toolbar.tsx
@@ -132,12 +132,17 @@ export default class CardToolbarComponent {
         chosenDeck: Deck,
         currentDeck: Deck,
         chosenDeckStats: DeckStats,
-        currentDeckStats: DeckStats,
+        currentDeckStats: DeckStats | null,
         totalCardsInSession: number,
         totalDecksInSession: number,
         currentDeckTotalCardsInQueue: number,
         flashcardCardOrder: string,
     ) {
+        const currentDeckProgress =
+            currentDeckStats === null
+                ? 0
+                : currentDeckTotalCardsInQueue - currentDeckStats.cardsInQueueOfThisDeckCount;
+
         this.infoSection.updateInfo(
             chosenDeck.deckName,
             totalCardsInSession,
@@ -146,7 +151,7 @@ export default class CardToolbarComponent {
             totalDecksInSession - chosenDeckStats.decksInQueueOfThisDeckCount,
             currentDeck.deckName,
             currentDeckTotalCardsInQueue,
-            currentDeckTotalCardsInQueue - currentDeckStats.cardsInQueueOfThisDeckCount,
+            currentDeckProgress,
             flashcardCardOrder === "EveryCardRandomDeckAndCard",
         );
     }

--- a/src/ui/obsidian-ui-components/content-container/content-manager.tsx
+++ b/src/ui/obsidian-ui-components/content-container/content-manager.tsx
@@ -375,41 +375,77 @@ export default class ContentManager {
     private async _doEditQuestionText(): Promise<void> {
         if (this.reviewSequencer === null) return;
         const currentCard: Card | null = this.reviewSequencer.currentCard;
+        if (currentCard === null) return;
         const currentQ: Question = this.reviewSequencer.currentQuestion;
 
         // Just the question/answer text; without any preceding topic tag
         const textPrompt = currentQ.questionText.actualQuestion;
-        const currentUIState = this.uiManager.uiState;
+        // Prefer the session's displayed side over uiManager.uiState. While the edit modal is
+        // open uiState becomes EditModal, and if anything leaves uiState out of sync with the
+        // card view we would otherwise skip the redraw after Save.
+        const previousCardState =
+            this.sessionData?.cardData.currentCardState ?? CardState.Front;
         this.uiManager.setUIState(UIState.EditModal);
-        const editModal = FlashcardEditModal.Prompt(
-            this.app,
-            this.settings,
-            currentCard,
-            textPrompt,
-            currentQ.questionText.textDirection,
-        );
-        await editModal
-            .then(async (modifiedCardText) => {
-                if (this.reviewSequencer === null) return;
-                await this.reviewSequencer.updateCurrentQuestionTextAndCards(modifiedCardText);
-                this.uiManager.setUIState(currentUIState);
 
-                if (this.sessionData !== null) {
-                    if (this.uiManager.uiState === UIState.CardFront) {
-                        await this.cardContainer.drawCardFront(this.sessionData, this.settings);
-                    }
+        try {
+            const modifiedCardText = await FlashcardEditModal.Prompt(
+                this.app,
+                this.settings,
+                currentCard,
+                textPrompt,
+                currentQ.questionText.textDirection,
+            );
 
-                    if (this.uiManager.uiState === UIState.CardBack) {
-                        await this.cardContainer.drawBack(
-                            this.sessionData,
-                            this.reviewMode,
-                            this.settings,
-                            this._determineButtonSchedule.bind(this),
-                        );
-                    }
-                }
-            })
-            .catch((reason) => console.log(reason));
+            if (this.reviewSequencer === null) return;
+
+            await this.reviewSequencer.updateCurrentQuestionTextAndCards(modifiedCardText);
+            await this._refreshCurrentCardView(previousCardState);
+        } catch (reason) {
+            // Cancel / empty input rejects with NO_INPUT — restore UI and ignore.
+            this.uiManager.setUIState(
+                previousCardState === CardState.Back ? UIState.CardBack : UIState.CardFront,
+            );
+            if (reason !== t("NO_INPUT")) {
+                console.error("SR: Failed to edit flashcard", reason);
+            }
+        }
+    }
+
+    /**
+     * Sync session data from the review sequencer and redraw the current card after an in-place
+     * edit. The note file is already updated; this refreshes the in-memory front/back in the UI.
+     */
+    private async _refreshCurrentCardView(cardState: CardState): Promise<void> {
+        if (this.reviewSequencer === null || this.sessionData === null) {
+            this.uiManager.setUIState(
+                cardState === CardState.Back ? UIState.CardBack : UIState.CardFront,
+            );
+            return;
+        }
+
+        // Sequencer owns the live Card objects after updateCurrentQuestionTextAndCards.
+        this.sessionData.cardData.currentCard = this.reviewSequencer.currentCard;
+        this.sessionData.currentQuestion = this.reviewSequencer.currentQuestion;
+        this.sessionData.currentNote = this.reviewSequencer.currentNote;
+        this.sessionData.cardData.currentCardState = cardState;
+
+        if (this.sessionData.cardData.currentCard === null) {
+            this.uiManager.setUIState(UIState.CardFront);
+            return;
+        }
+
+        if (cardState === CardState.Back) {
+            this.uiManager.setUIState(UIState.CardBack);
+            await this.cardContainer.drawBack(
+                this.sessionData,
+                this.reviewMode,
+                this.settings,
+                this._determineButtonSchedule.bind(this),
+            );
+        } else {
+            this.uiManager.setUIState(UIState.CardFront);
+            await this.cardContainer.drawCardFront(this.sessionData, this.settings);
+        }
     }
 
     public async _jumpToCurrentCard(): Promise<void> {

--- a/src/ui/obsidian-ui-components/content-container/content-manager.tsx
+++ b/src/ui/obsidian-ui-components/content-container/content-manager.tsx
@@ -383,8 +383,7 @@ export default class ContentManager {
         // Prefer the session's displayed side over uiManager.uiState. While the edit modal is
         // open uiState becomes EditModal, and if anything leaves uiState out of sync with the
         // card view we would otherwise skip the redraw after Save.
-        const previousCardState =
-            this.sessionData?.cardData.currentCardState ?? CardState.Front;
+        const previousCardState = this.sessionData?.cardData.currentCardState ?? CardState.Front;
         this.uiManager.setUIState(UIState.EditModal);
 
         try {

--- a/tests/unit/scheduling/flashcard-review-sequencer.test.ts
+++ b/tests/unit/scheduling/flashcard-review-sequencer.test.ts
@@ -1348,6 +1348,23 @@ async function checkupdateCurrentQuestionTextAndCards(
     }
     const expectedFileText: string = c.originalText.replace(originalStr, updatedStr);
     expect(await c.file.read()).toEqual(expectedFileText);
+
+    // Review UI reads these in-memory faces after Save; they must update with the file.
+    // Prefer single-line split; fall back to multiline line-based separator.
+    let expectedFront: string;
+    let expectedBack: string;
+    if (updatedQ.includes(settings.singleLineCardSeparator)) {
+        const idx = updatedQ.indexOf(settings.singleLineCardSeparator);
+        expectedFront = updatedQ.substring(0, idx);
+        expectedBack = updatedQ.substring(idx + settings.singleLineCardSeparator.length);
+    } else {
+        const lines = updatedQ.split("\n");
+        const sepIdx = lines.findIndex((line) => line.trim() === settings.multilineCardSeparator);
+        expectedFront = lines.slice(0, sepIdx).join("\n");
+        expectedBack = lines.slice(sepIdx + 1).join("\n");
+    }
+    expect(c.reviewSequencer.currentCard.front).toEqual(expectedFront);
+    expect(c.reviewSequencer.currentCard.back).toEqual(expectedBack);
     return c;
 }
 


### PR DESCRIPTION
## Summary

- After pressing **Save** in the pencil edit modal, the markdown note was updated correctly but the open flashcard review view could still show the previous front/answer text.
- Root cause: the review session was not reliably re-synced from the sequencer after `updateCurrentQuestionTextAndCards`, redraw depended on `uiManager.uiState` (which is `EditModal` during the edit flow and can drift from the displayed card side), and a card-count mismatch aborted all in-memory `front`/`back` updates even though the file had already been written.
- This PR always refreshes session card/question/note from the sequencer, redraws from the displayed card side (`CardFront` / `CardBack`), updates overlapping in-memory faces after every successful write, and hardens null-safe drawing / toolbar stats.

## Changes

- `content-manager.tsx`: `_doEditQuestionText` now restores via `_refreshCurrentCardView`, keyed off session card state rather than UI state alone.
- `flashcard-review-sequencer.ts`: always update overlapping card faces after write; warn if sibling count changed instead of leaving stale faces.
- `card-container.tsx` / `toolbar.tsx`: null-safe current card and deck stats during redraw.
- Tests: assert in-memory `front`/`back` update after edit for single-line and multiline cards.

## Test plan

- [x] `jest` `updateCurrentQuestionTextAndCards` + Sequences suites
- [x] `tsc -noEmit -skipLibCheck`
- [ ] Manual: open flashcard review → pencil edit front and/or answer → Save → confirm the open card (and Show Answer side) updates immediately without leaving/reopening review
- [ ] Manual: edit while answer is already shown → Save → confirm both sides refresh
- [ ] Manual: cloze edit that changes deletion count → Save → current card text updates; notice about sibling re-parse is acceptable