### PR TITLE
fix: keep focus when opening things in background

### DIFF
--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -48,6 +48,7 @@ export class CommandManager {
         this.plugin.removeCommand("srs-card-review-show-answer");
         this.plugin.removeCommand("srs-card-review-reset");
         this.plugin.removeCommand("srs-card-review-skip");
+        this.plugin.removeCommand("srs-card-review-open-in-background");
     }
 
     /**
@@ -266,13 +267,14 @@ export class CommandManager {
         });
 
         this.plugin.addCommand({
-            id: "srs-card-review-reset",
+            id: "srs-card-review-open-in-background",
             name: t("OPEN_IN_BACKGROUND"),
             repeatable: false,
             checkCallback: (checking: boolean) => {
                 if (
                     this.plugin.isInitialized &&
-                    this.uiManager.uiState === UIState.CardBack &&
+                    (this.uiManager.uiState === UIState.CardBack ||
+                        this.uiManager.uiState === UIState.CardFront) &&
                     this.uiManager.isSRInFocus &&
                     this.uiManager.contentManager !== null &&
                     !(

--- a/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
+++ b/src/ui/obsidian-ui-components/content-container/card-container/card-container.tsx
@@ -185,6 +185,8 @@ export class CardContainer {
             if (firstInput) {
                 firstInput.focus();
             }
+        } else {
+            this.plugin.uiManager.focusModal();
         }
     }
 

--- a/src/ui/obsidian-ui-components/content-container/content-manager.tsx
+++ b/src/ui/obsidian-ui-components/content-container/content-manager.tsx
@@ -417,12 +417,13 @@ export default class ContentManager {
         const currentQuestion = this.reviewSequencer.currentQuestion;
         if (!currentQuestion) return;
 
-        if (
+        const isModal =
             (!this.settings.openViewInNewTab &&
                 !(Platform.isMobile || EmulatedPlatform().isMobile)) ||
             (!this.settings.openViewInNewTabMobile &&
-                (Platform.isMobile || EmulatedPlatform().isMobile))
-        ) {
+                (Platform.isMobile || EmulatedPlatform().isMobile));
+
+        if (isModal) {
             new Notice("Note was opened in new tab in the background");
         }
 
@@ -432,6 +433,9 @@ export default class ContentManager {
 
         if (blockId) {
             await this.app.workspace.openLinkText(`${file.path}#${blockId}`, file.path, false);
+            if (isModal) {
+                this.uiManager.focusModal();
+            }
             return;
         }
 
@@ -449,6 +453,9 @@ export default class ContentManager {
                 markdownView.editor.setCursor({ line, ch: 0 });
                 markdownView.editor.scrollIntoView({ from: { line, ch: 0 }, to: { line, ch: 0 } });
             }
+            if (isModal) {
+                this.uiManager.focusModal();
+            }
             return;
         }
 
@@ -459,6 +466,10 @@ export default class ContentManager {
         if (markdownView?.editor) {
             markdownView.editor.setCursor({ line, ch: 0 });
             markdownView.editor.scrollIntoView({ from: { line, ch: 0 }, to: { line, ch: 0 } });
+        }
+
+        if (isModal) {
+            this.uiManager.focusModal();
         }
     }
 

--- a/src/ui/obsidian-ui-components/modals/sr-modal-view.tsx
+++ b/src/ui/obsidian-ui-components/modals/sr-modal-view.tsx
@@ -43,6 +43,8 @@ export class SRModalView extends Modal {
 
         this.modalEl.setAttribute("id", "sr-modal-view");
         this.modalEl.addClass("sr-view");
+        // allows the modal to be focused
+        this.modalEl.setAttribute("tabindex", "-1");
 
         this.contentEl.addClass("sr-modal-content");
 
@@ -60,11 +62,21 @@ export class SRModalView extends Modal {
         this.plugin.uiManager.setContentManager(this.contentManager);
     }
 
+    public focus(): void {
+        if (!this.modalEl.contains(activeDocument.activeElement)) {
+            this.modalEl.focus();
+        }
+    }
+
     onOpen(): void {
+        this.focus();
         void this.contentManager.open();
     }
 
     onClose(): void {
+        if (this.plugin.uiManager.modalView === this) {
+            this.plugin.uiManager.modalView = null;
+        }
         this.contentManager.close();
     }
 

--- a/src/ui/ui-manager.tsx
+++ b/src/ui/ui-manager.tsx
@@ -54,6 +54,7 @@ export class UIManager {
     public uiState: UIState = UIState.Closed;
     public isSRInFocus: boolean = false;
     public contentManager: ContentManager | null = null;
+    public modalView: SRModalView | null = null;
 
     private plugin: SRPlugin;
     private settingsManager: SettingsManager;
@@ -162,6 +163,10 @@ export class UIManager {
     }
 
     public handleFocusChange(leaf: WorkspaceLeaf | null) {
+        if (this.modalView !== null) {
+            this.setSRViewInFocus(true);
+            return;
+        }
         this.setSRViewInFocus(
             leaf !== null && leaf !== undefined && leaf.view instanceof SRTabView,
         );
@@ -209,7 +214,9 @@ export class UIManager {
 
         const activeLeaf = this.plugin.app.workspace.activeLeaf;
         if (activeLeaf !== null) {
-            this.plugin.app.workspace.setActiveLeaf(activeLeaf, { focus: true });
+            if (this.modalView === null) {
+                this.plugin.app.workspace.setActiveLeaf(activeLeaf, { focus: true });
+            }
             activeLeaf.getContainer()?.win?.focus();
         }
         activeDocument.defaultView?.focus();
@@ -426,21 +433,29 @@ export class UIManager {
 
         if (openInNewTab) {
             await this.tabViewManager.openSRTabView(reviewQueueLoader);
+            this.focusObsidianWindow();
         } else {
             this.openFlashcardModal(reviewQueueLoader);
         }
-        this.focusObsidianWindow();
     }
 
     public openFlashcardModal(reviewQueueLoader: ReviewQueueLoader): void {
         this.setSRViewInFocus(true);
         this.focusObsidianWindow();
-        new SRModalView(
+        this.modalView = new SRModalView(
             this.plugin.app,
             this.plugin,
             this.settingsManager,
             reviewQueueLoader,
-        ).open();
+        );
+        this.modalView.open();
+    }
+
+    public focusModal(): void {
+        if (this.modalView !== null) {
+            this.modalView.focus();
+            this.setSRViewInFocus(true);
+        }
     }
 
     public setSRViewInFocus(value: boolean) {


### PR DESCRIPTION
For #1586 

Adds tabindex -1 to the modal so it can be focused see; https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex

also fix duplicate id for command