### PR TITLE
fix: remove duplicate setting

### DIFF
--- a/src/ui/obsidian-ui-components/content-container/settings-page/flashcards-page.tsx
+++ b/src/ui/obsidian-ui-components/content-container/settings-page/flashcards-page.tsx
@@ -124,19 +124,6 @@ export class FlashcardsPage extends SettingsPage {
         new SettingGroup(this.containerEl)
             .setHeading(t("GROUP_FLASHCARD_REVIEW"))
             .addSetting((setting: Setting) => {
-                setting
-                    .setName(t("BURY_SIBLINGS_TILL_NEXT_DAY"))
-                    .setDesc(t("BURY_SIBLINGS_TILL_NEXT_DAY_DESC"))
-                    .addToggle((toggle) =>
-                        toggle
-                            .setValue(this.settingsManager.settings.burySiblingCards)
-                            .onChange(async (value) => {
-                                this.settingsManager.settings.burySiblingCards = value;
-                                await this.settingsManager.save();
-                            }),
-                    );
-            })
-            .addSetting((setting: Setting) => {
                 setting.setName(t("REVIEW_CARD_ORDER_WITHIN_DECK")).addDropdown((dropdown) =>
                     dropdown
                         .addOptions({


### PR DESCRIPTION
Closes #1621

Removes one of the duplicate settings;

https://github.com/st3v3nmw/obsidian-spaced-repetition/blob/3d5079f3bcd54531b084040d1c0178f15f681510/src/ui/obsidian-ui-components/content-container/settings-page/flashcards-page.tsx#L75-L87

https://github.com/st3v3nmw/obsidian-spaced-repetition/blob/3d5079f3bcd54531b084040d1c0178f15f681510/src/ui/obsidian-ui-components/content-container/settings-page/flashcards-page.tsx#L126-L138